### PR TITLE
fix: Replace error name when navigator.permissions is not supported

### DIFF
--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -10,7 +10,8 @@ describe('getPermission', () => {
 			try {
 				await getPermission()
 			} catch (error) {
-				expect(error).toEqual(new DOMException('Permissions not supported', 'NOT_FOUND_ERR'))
+				expect(error.message).toEqual('Permissions not supported')
+				expect(error.name).toEqual('NOT_SUPPORTED_ERR')
 			}
 		})
 	})
@@ -46,7 +47,8 @@ describe('getPermission', () => {
 			try {
 				await getPermission()
 			} catch (error) {
-				expect(error).toEqual(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+				expect(error.message).toEqual('Permission denied')
+				expect(error.name).toEqual('NOT_ALLOWED_ERR')
 			}
 		})
 
@@ -77,7 +79,8 @@ describe('getPermission', () => {
 			try {
 				await getPermission()
 			} catch (error) {
-				expect(error).toEqual(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+				expect(error.message).toEqual('Permission denied')
+				expect(error.name).toEqual('NOT_ALLOWED_ERR')
 			}
 		})
 

--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -10,7 +10,8 @@ describe('getUserMediaStream', () => {
 			try {
 				await getUserMediaStream()
 			} catch (error) {
-				expect(error).toEqual(new DOMException('MediaDevices not supported', 'NOT_FOUND_ERR'))
+				expect(error.message).toEqual('MediaDevices not supported')
+				expect(error.name).toEqual('NOT_FOUND_ERR')
 			}
 		})
 	})
@@ -51,7 +52,8 @@ describe('getUserMediaStream', () => {
 				try {
 					await getUserMediaStream()
 				} catch (error) {
-					expect(error).toEqual(new DOMException('MediaDevices not supported', 'NOT_FOUND_ERR'))
+					expect(error.message).toEqual('MediaDevices not supported')
+					expect(error.name).toEqual('NOT_FOUND_ERR')
 				}
 			})
 		})
@@ -82,7 +84,8 @@ describe('getUserMediaStream', () => {
 				try {
 					await getUserMediaStream()
 				} catch (error) {
-					expect(error).toEqual(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+					expect(error.message).toEqual('Permission denied')
+					expect(error.name).toEqual('NOT_ALLOWED_ERR')
 				}
 			})
 
@@ -115,7 +118,8 @@ describe('getUserMediaStream', () => {
 				try {
 					await getUserMediaStream()
 				} catch (error) {
-					expect(error).toEqual(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+					expect(error.message).toEqual('Permission denied')
+					expect(error.name).toEqual('NOT_ALLOWED_ERR')
 				}
 			})
 

--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -6,7 +6,7 @@
 export default async (permissionName) => {
 	return new Promise(async (resolve, reject) => {
 		if (!navigator.permissions) {
-			reject(new DOMException('Permissions not supported', 'NOT_FOUND_ERR'))
+			reject(new DOMException('Permissions not supported', 'NOT_SUPPORTED_ERR'))
 		} else {
 			try {
 				const permissionStatus = await navigator.permissions.query({ name: permissionName })


### PR DESCRIPTION
Closes #16 