### PR TITLE
fix(getPermission): do not resolve promise when permission state is 'prompt'

### DIFF
--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -13,12 +13,15 @@ export default async (permissionName) => {
 
 		try {
 			const permissionStatus = await navigator.permissions.query({ name: permissionName })
-			const onChange = (event) => {
-				permissionStatus.removeEventListener('change', onChange)
-				resolveOrRejectBasedOnState(event.target.state, resolve, reject)
+			if (permissionStatus.state === 'prompt') {
+				const onChange = (event) => {
+					permissionStatus.removeEventListener('change', onChange)
+					resolveOrRejectBasedOnState(event.target.state, resolve, reject)
+				}
+				permissionStatus.addEventListener('change', onChange)
+			} else {
+				resolveOrRejectBasedOnState(permissionStatus.state, resolve, reject)
 			}
-			permissionStatus.addEventListener('change', onChange)
-			resolveOrRejectBasedOnState(permissionStatus.state, resolve, reject)
 		} catch (error) {
 			reject(error)
 		}

--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -27,10 +27,12 @@ export default async (permissionName) => {
 
 const resolveOrRejectBasedOnState = (state, resolve, reject) => {
 	switch (state) {
+		case 'granted':
+			resolve(state)
+			break
 		case 'denied':
 			reject(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
 			break
-		default:
-			resolve(state)
+		// 'prompt': stay pending — onChange will settle the promise once the user decides
 	}
 }


### PR DESCRIPTION
## Summary

`getPermission` was immediately resolving the promise with `'prompt'` when the permission dialog hadn't been shown yet. The `onChange` event listener was effectively dead code since the promise was already settled before the user could interact.

## Changes

- `src/getPermission.js` — Add explicit `'granted'` case to `resolveOrRejectBasedOnState` and remove the `default` catch-all. When state is `'prompt'`, the function is now a no-op — the `onChange` listener already registered settles the promise once the user grants or denies.

## Test plan

- [x] All 19 existing tests pass (prompt→granted and prompt→denied paths already covered via synchronous `addEventListener` mock)
- [x] Build passes
- [x] Coverage 100%

Closes #66