### PR TITLE
fix(guards): return after reject() in unsupported-API guard clauses

### DIFF
--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -8,7 +8,7 @@ import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
 export default async (permissionName) => {
 	return new Promise(async (resolve, reject) => {
 		if (!isNavigatorPermissionsSupported()) {
-			reject(new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR'))
+			return reject(new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR'))
 		}
 
 		try {

--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -11,7 +11,7 @@ import getPermission from './getPermission'
 export default async (permissionName, mediaStreamConstraints) => {
 	return new Promise(async (resolve, reject) => {
 		if (!isNavigatorPermissionsSupported() || !isNavigatorMediaDevicesSupported()) {
-			reject(
+			return reject(
 				new DOMException(
 					'Navigator API: permissions or Navigator API: mediaDevices not supported',
 					'NOT_SUPPORTED_ERR'


### PR DESCRIPTION
## Summary

In both `getPermission` and `getUserMediaStream`, calling `reject()` in the unsupported-API guard did not stop execution. Code continued into the `try` block and attempted to call `navigator.permissions.query()` or `Promise.all()` on `undefined` APIs, producing a silent secondary `TypeError` swallowed by the outer `catch`.

## Changes

- `src/getPermission.js` — `reject(...)` → `return reject(...)` in the `isNavigatorPermissionsSupported` guard
- `src/getUserMediaStream.js` — `reject(...)` → `return reject(...)` in the `isNavigatorPermissionsSupported || isNavigatorMediaDevicesSupported` guard

## Test plan

- [x] All 19 existing tests pass
- [x] Build passes
- [x] Coverage 100%

Closes #67