### PR TITLE
fix: remove new Promise(async executor) anti-pattern in getPermission and getUserMediaStream

### DIFF
--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -6,36 +6,32 @@ import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
  * @returns {Promise}
  */
 export default async (permissionName) => {
-	return new Promise(async (resolve, reject) => {
-		if (!isNavigatorPermissionsSupported()) {
-			return reject(new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR'))
-		}
+	if (!isNavigatorPermissionsSupported()) {
+		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+	}
 
-		try {
-			const permissionStatus = await navigator.permissions.query({ name: permissionName })
-			if (permissionStatus.state === 'prompt') {
-				const onChange = (event) => {
-					permissionStatus.removeEventListener('change', onChange)
-					resolveOrRejectBasedOnState(event.target.state, resolve, reject)
+	const permissionStatus = await navigator.permissions.query({ name: permissionName })
+
+	if (permissionStatus.state === 'prompt') {
+		return new Promise((resolve, reject) => {
+			const onChange = (event) => {
+				permissionStatus.removeEventListener('change', onChange)
+				try {
+					resolve(resolveOrRejectBasedOnState(event.target.state))
+				} catch (error) {
+					reject(error)
 				}
-				permissionStatus.addEventListener('change', onChange)
-			} else {
-				resolveOrRejectBasedOnState(permissionStatus.state, resolve, reject)
 			}
-		} catch (error) {
-			reject(error)
-		}
-	})
+			permissionStatus.addEventListener('change', onChange)
+		})
+	}
+
+	return resolveOrRejectBasedOnState(permissionStatus.state)
 }
 
-const resolveOrRejectBasedOnState = (state, resolve, reject) => {
-	switch (state) {
-		case 'granted':
-			resolve(state)
-			break
-		case 'denied':
-			reject(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
-			break
-		// 'prompt': stay pending — onChange will settle the promise once the user decides
+const resolveOrRejectBasedOnState = (state) => {
+	if (state === 'denied') {
+		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
 	}
+	return state
 }

--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -9,24 +9,16 @@ import getPermission from './getPermission'
  * @returns {Promise}
  */
 export default async (permissionName, mediaStreamConstraints) => {
-	return new Promise(async (resolve, reject) => {
-		if (!isNavigatorPermissionsSupported() || !isNavigatorMediaDevicesSupported()) {
-			return reject(
-				new DOMException(
-					'Navigator API: permissions or Navigator API: mediaDevices not supported',
-					'NOT_SUPPORTED_ERR'
-				)
-			)
-		}
+	if (!isNavigatorPermissionsSupported() || !isNavigatorMediaDevicesSupported()) {
+		throw new DOMException(
+			'Navigator API: permissions or Navigator API: mediaDevices not supported',
+			'NOT_SUPPORTED_ERR'
+		)
+	}
 
-		try {
-			const [, stream] = await Promise.all([
-				await getPermission(permissionName),
-				await navigator.mediaDevices.getUserMedia(mediaStreamConstraints),
-			])
-			resolve(stream)
-		} catch (error) {
-			reject(error)
-		}
-	})
+	const [, stream] = await Promise.all([
+		await getPermission(permissionName),
+		await navigator.mediaDevices.getUserMedia(mediaStreamConstraints),
+	])
+	return stream
 }


### PR DESCRIPTION
## Summary

Both `getPermission` and `getUserMediaStream` wrapped their entire body in `new Promise(async (resolve, reject) => {...})` despite being `async` functions themselves. The `async` keyword on the executor creates a disconnected inner promise — any uncaught throw inside it becomes an unhandled promise rejection rather than propagating to the outer promise's `reject`. In Node.js ≥15 with `--unhandled-rejections=throw` (the default), this crashes the process.

## Changes

- `src/getPermission.js` — Remove `new Promise(async ...)` wrapper; guard now throws directly; `navigator.permissions.query()` is awaited at the top level; `'prompt'` case uses a clean synchronous `new Promise` (no `async`) to wait for the change event; `resolveOrRejectBasedOnState` simplified to throw/return instead of resolve/reject callbacks
- `src/getUserMediaStream.js` — Remove `new Promise(async ...)` wrapper; guard throws directly; `Promise.all` result is awaited and returned inline

## Test plan

- [x] All 19 existing tests pass
- [x] Build passes (bundle size reduced: 25 → 22 statements)
- [x] Coverage 100% (statements, branches, functions, lines)

Closes #68