### PR TITLE
fix(getUserMediaStream): replace no-op Promise.all with explicit sequential awaits

### DIFF
--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -16,9 +16,6 @@ export default async (permissionName, mediaStreamConstraints) => {
 		)
 	}
 
-	const [, stream] = await Promise.all([
-		await getPermission(permissionName),
-		await navigator.mediaDevices.getUserMedia(mediaStreamConstraints),
-	])
-	return stream
+	await getPermission(permissionName)
+	return navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
 }


### PR DESCRIPTION
## Summary

`getUserMediaStream` used `await` on each argument inside `Promise.all`, which caused both operations to execute sequentially before `Promise.all` was even invoked — the concurrency wrapper received only already-settled values and was entirely redundant. The misleading structure also obscured the intended sequencing: permission must be resolved before the media stream is requested.

## Changes

- `src/getUserMediaStream.js` — Replace `Promise.all([await getPermission(...), await getUserMedia(...)])` with two explicit sequential `await` calls: `await getPermission(permissionName)` then `return navigator.mediaDevices.getUserMedia(mediaStreamConstraints)`

## Test plan

- [x] All 19 existing tests pass
- [x] Build passes
- [x] Coverage 100%

Closes #69