### PR TITLE
test: replace try/catch rejection tests with expect().rejects

### DIFF
--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -7,12 +7,10 @@ describe('getPermission', () => {
 		})
 
 		it('rejects promise', async () => {
-			try {
-				await getPermission()
-			} catch (error) {
-				expect(error.message).toEqual('Navigator API: permissions not supported')
-				expect(error.name).toEqual('NOT_SUPPORTED_ERR')
-			}
+			await expect(getPermission()).rejects.toMatchObject({
+				message: 'Navigator API: permissions not supported',
+				name: 'NOT_SUPPORTED_ERR',
+			})
 		})
 	})
 
@@ -42,75 +40,47 @@ describe('getPermission', () => {
 			const status = new PermissionStatus()
 			status.state = 'denied'
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			try {
-				await getPermission()
-			} catch (error) {
-				expect(error.message).toEqual('Permission denied')
-				expect(error.name).toEqual('NOT_ALLOWED_ERR')
-			}
+			await expect(getPermission()).rejects.toMatchObject({
+				message: 'Permission denied',
+				name: 'NOT_ALLOWED_ERR',
+			})
 		})
 
 		it('resolves promise since user has previously granted permission', async () => {
 			const status = new PermissionStatus()
 			status.state = 'granted'
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			try {
-				const status = await getPermission()
-				expect(status).toBe('granted')
-			} catch (error) {
-				throw error
-			}
+			await expect(getPermission()).resolves.toBe('granted')
 		})
 
 		it('rejects promise since user has been prompted and has denied permissions', async () => {
 			const status = new PermissionStatus()
 			status.state = 'prompt'
 			status.addEventListener = vi.fn((e, cb) => {
-				const event = {
-					target: {
-						state: 'denied',
-					},
-				}
-				cb(event)
+				cb({ target: { state: 'denied' } })
 			})
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			try {
-				await getPermission()
-			} catch (error) {
-				expect(error.message).toEqual('Permission denied')
-				expect(error.name).toEqual('NOT_ALLOWED_ERR')
-			}
+			await expect(getPermission()).rejects.toMatchObject({
+				message: 'Permission denied',
+				name: 'NOT_ALLOWED_ERR',
+			})
 		})
 
 		it('resolves promise since user has been prompted and has granted permissions', async () => {
 			const status = new PermissionStatus()
 			status.state = 'prompt'
 			status.addEventListener = vi.fn((e, cb) => {
-				const event = {
-					target: {
-						state: 'granted',
-					},
-				}
-				cb(event)
+				cb({ target: { state: 'granted' } })
 			})
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			try {
-				const status = await getPermission()
-				expect(status).toBe('granted')
-			} catch (error) {
-				throw error
-			}
+			await expect(getPermission()).resolves.toBe('granted')
 		})
 
 		it('throws error', async () => {
 			mockPermissionsQuery.mockImplementationOnce(() => {
 				throw new Error('ERR')
 			})
-			try {
-				await getPermission()
-			} catch (error) {
-				expect(error).toEqual(new Error('ERR'))
-			}
+			await expect(getPermission()).rejects.toEqual(new Error('ERR'))
 		})
 	})
 })

--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -7,12 +7,10 @@ describe('getUserMediaStream', () => {
 		})
 
 		it('rejects promise', async () => {
-			try {
-				await getUserMediaStream()
-			} catch (error) {
-				expect(error.message).toEqual('Navigator API: permissions or Navigator API: mediaDevices not supported')
-				expect(error.name).toEqual('NOT_SUPPORTED_ERR')
-			}
+			await expect(getUserMediaStream()).rejects.toMatchObject({
+				message: 'Navigator API: permissions or Navigator API: mediaDevices not supported',
+				name: 'NOT_SUPPORTED_ERR',
+			})
 		})
 	})
 
@@ -47,14 +45,10 @@ describe('getUserMediaStream', () => {
 				const status = new PermissionStatus()
 				status.state = 'prompt'
 				mockPermissionsQuery.mockResolvedValueOnce(status)
-				try {
-					await getUserMediaStream()
-				} catch (error) {
-					expect(error.message).toEqual(
-						'Navigator API: permissions or Navigator API: mediaDevices not supported'
-					)
-					expect(error.name).toEqual('NOT_SUPPORTED_ERR')
-				}
+				await expect(getUserMediaStream()).rejects.toMatchObject({
+					message: 'Navigator API: permissions or Navigator API: mediaDevices not supported',
+					name: 'NOT_SUPPORTED_ERR',
+				})
 			})
 		})
 
@@ -81,12 +75,10 @@ describe('getUserMediaStream', () => {
 				status.state = 'denied'
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 				mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
-				try {
-					await getUserMediaStream()
-				} catch (error) {
-					expect(error.message).toEqual('Permission denied')
-					expect(error.name).toEqual('NOT_ALLOWED_ERR')
-				}
+				await expect(getUserMediaStream()).rejects.toMatchObject({
+					message: 'Permission denied',
+					name: 'NOT_ALLOWED_ERR',
+				})
 			})
 
 			it('resolves promise with stream since user has previously granted permission', async () => {
@@ -94,65 +86,39 @@ describe('getUserMediaStream', () => {
 				status.state = 'granted'
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 				mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
-				try {
-					const stream = await getUserMediaStream()
-					expect(stream).toBe('foo')
-				} catch (error) {
-					throw error
-				}
+				await expect(getUserMediaStream()).resolves.toBe('foo')
 			})
 
 			it('rejects promise since user has been prompted and has denied permissions', async () => {
 				const status = new PermissionStatus()
 				status.state = 'prompt'
 				status.addEventListener = vi.fn((e, cb) => {
-					const event = {
-						target: {
-							state: 'denied',
-						},
-					}
-					cb(event)
+					cb({ target: { state: 'denied' } })
 				})
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 				mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
-				try {
-					await getUserMediaStream()
-				} catch (error) {
-					expect(error.message).toEqual('Permission denied')
-					expect(error.name).toEqual('NOT_ALLOWED_ERR')
-				}
+				await expect(getUserMediaStream()).rejects.toMatchObject({
+					message: 'Permission denied',
+					name: 'NOT_ALLOWED_ERR',
+				})
 			})
 
 			it('resolves promise with stream since user has been prompted and has granted permissions', async () => {
 				const status = new PermissionStatus()
 				status.state = 'prompt'
 				status.addEventListener = vi.fn((e, cb) => {
-					const event = {
-						target: {
-							state: 'granted',
-						},
-					}
-					cb(event)
+					cb({ target: { state: 'granted' } })
 				})
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 				mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
-				try {
-					const stream = await getUserMediaStream()
-					expect(stream).toBe('foo')
-				} catch (error) {
-					throw error
-				}
+				await expect(getUserMediaStream()).resolves.toBe('foo')
 			})
 
 			it('throws since error is raised from permissions', async () => {
 				mockPermissionsQuery.mockImplementationOnce(() => {
 					throw new Error('ERR')
 				})
-				try {
-					await getUserMediaStream()
-				} catch (error) {
-					expect(error).toEqual(new Error('ERR'))
-				}
+				await expect(getUserMediaStream()).rejects.toEqual(new Error('ERR'))
 			})
 
 			it('throws since error is raised from mediaDevices', async () => {
@@ -162,11 +128,7 @@ describe('getUserMediaStream', () => {
 				mockMediaDevicesGetUserMedia.mockImplementationOnce(() => {
 					throw new Error('ERR')
 				})
-				try {
-					await getUserMediaStream()
-				} catch (error) {
-					expect(error).toEqual(new Error('ERR'))
-				}
+				await expect(getUserMediaStream()).rejects.toEqual(new Error('ERR'))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

All rejection tests used a `try/catch` pattern that passed silently when no error was thrown — if the function resolved instead of rejecting, the `catch` block was never entered and the test reported success with zero assertions. Resolution tests used `try { ... } catch (e) { throw e }` which is a no-op.

## Changes

- `src/__tests__/getPermission.test.js` — Replace 4 rejection blocks with `expect().rejects.toMatchObject()`, 2 resolution blocks with `expect().resolves.toBe()`
- `src/__tests__/getUserMediaStream.test.js` — Replace 5 rejection blocks with `expect().rejects.toMatchObject()`, 2 error-throw blocks with `expect().rejects.toEqual()`, 1 resolution block with `expect().resolves.toBe()`

## Test plan

- [x] All 19 tests pass
- [x] Coverage 100%

Closes #72