### PR TITLE
fix(test): correct describe title in isNavigatorMediaDevicesSupported test

### DIFF
--- a/src/__tests__/isNavigatorMediaDevicesSupported.test.js
+++ b/src/__tests__/isNavigatorMediaDevicesSupported.test.js
@@ -1,6 +1,6 @@
 import isNavigatorMediaDevicesSupported from '../isNavigatorMediaDevicesSupported'
 
-describe('isNavigatorPermissionsSupported', () => {
+describe('isNavigatorMediaDevicesSupported', () => {
 	describe('navigator.permissions is not implemented', () => {
 		beforeAll(() => {
 			global.navigator.permissions = undefined


### PR DESCRIPTION
## Summary

The root `describe` block in `isNavigatorMediaDevicesSupported.test.js` was titled `'isNavigatorPermissionsSupported'` due to a copy-paste error, causing test reporters and CI logs to attribute failures to the wrong function.

## Changes

- `src/__tests__/isNavigatorMediaDevicesSupported.test.js` — rename root `describe` from `'isNavigatorPermissionsSupported'` to `'isNavigatorMediaDevicesSupported'`

## Test plan

- [x] All 19 tests pass
- [x] Coverage 100%

Closes #70