### PR TITLE
docs: document isNavigatorPermissionsSupported and isNavigatorMediaDevicesSupported in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,30 @@ const init = async () => {
 }
 ```
 
+`isNavigatorPermissionsSupported`:
+
+Returns `true` if the browser supports `navigator.permissions`
+
+```javascript
+import { isNavigatorPermissionsSupported } from '@untemps/user-permissions-utils'
+
+if (!isNavigatorPermissionsSupported()) {
+    console.warn('Navigator Permissions API is not supported in this browser')
+}
+```
+
+`isNavigatorMediaDevicesSupported`:
+
+Returns `true` if the browser supports `navigator.mediaDevices`
+
+```javascript
+import { isNavigatorMediaDevicesSupported } from '@untemps/user-permissions-utils'
+
+if (!isNavigatorMediaDevicesSupported()) {
+    console.warn('Navigator MediaDevices API is not supported in this browser')
+}
+```
+
 ## Todos
 
 -   Add permissions-based API:


### PR DESCRIPTION
## Summary

`isNavigatorPermissionsSupported` and `isNavigatorMediaDevicesSupported` were public exports with zero documentation — not mentioned anywhere in `README.md`. Consumers had no way to discover them short of reading the source.

## Changes

- `README.md` — Add a section for each guard function with a description and usage example, consistent with the existing `getPermission` and `getUserMediaStream` sections

## Test plan

- [x] All 19 tests pass
- [x] Coverage 100%

Closes #71