### PR TITLE
chore(package): add engines field (node >=22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
 	],
 	"author": "Vincent Le Badezet <v.lebadezet@untemps.net>",
 	"license": "MIT",
+	"engines": {
+		"node": ">=22"
+	},
 	"private": false,
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Summary

`package.json` had no `engines` field, leaving the Node.js version requirement undeclared. `semantic-release@25` requires `^22.14.0 || >=24.10.0` and the CI workflow targets Node 22 — contributors on older versions had no upfront warning.

## Changes

- `package.json` — Add `"engines": { "node": ">=22" }`

## Test plan

- [x] All 19 tests pass
- [x] Coverage 100%

Closes #74