### PR TITLE
chore(coverage): enforce 100% thresholds in vitest config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -21,6 +21,12 @@ export default defineConfig({
 			provider: 'v8',
 			reporter: ['text', 'lcov'],
 			reportsDirectory: './coverage',
+			thresholds: {
+				statements: 100,
+				branches: 100,
+				functions: 100,
+				lines: 100,
+			},
 		},
 	},
 })


### PR DESCRIPTION
## Summary

Coverage was collected on every CI run but thresholds were never enforced. A test deletion or logic regression could silently reduce coverage without failing the build. Thresholds lock in the current 100% across all four metrics.

## Changes

- `vite.config.js` — Add `thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 }` to `test.coverage`

## Test plan

- [x] All 19 tests pass with thresholds active
- [x] Coverage 100% on all metrics (statements, branches, functions, lines)

Closes #75