### PR TITLE
chore(build): disable sourcemaps to reduce npm package size

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
 				return 'index.umd.js'
 			},
 		},
-		sourcemap: true,
+		sourcemap: false,
 	},
 	test: {
 		environment: 'jsdom',


### PR DESCRIPTION
## Summary

`sourcemap: true` in `vite.config.js` generated `.map` files that were included in the published npm package via `files: ["dist"]`. The library is open source with no sensitive logic — sourcemaps on npm add no value and significantly increase install size.

## Changes

- `vite.config.js` — `sourcemap: true` → `sourcemap: false`

## Test plan

- [x] All 19 tests pass
- [x] Build produces only `dist/index.js`, `dist/index.es.js`, `dist/index.umd.js` — no `.map` files
- [x] Coverage 100%

Closes #76