### PR TITLE
feat(types): add TypeScript declarations for all public exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
 	},
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",
+	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.es.js",
 			"require": "./dist/index.js",
 			"default": "./dist/index.es.js"
@@ -65,7 +67,7 @@
 	"scripts": {
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
-		"build": "vite build",
+		"build": "vite build && cp src/index.d.ts dist/index.d.ts",
 		"prettier": "prettier \"*/**/*.js\" --ignore-path ./.prettierignore --write",
 		"prepare": "husky"
 	}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,7 @@
+export declare function getPermission(permissionName: PermissionName): Promise<PermissionState>
+export declare function getUserMediaStream(
+	permissionName: PermissionName,
+	constraints: MediaStreamConstraints
+): Promise<MediaStream>
+export declare function isNavigatorPermissionsSupported(): boolean
+export declare function isNavigatorMediaDevicesSupported(): boolean


### PR DESCRIPTION
## Summary

The library had no TypeScript type declarations, leaving TypeScript consumers without autocompletion or type safety. A handwritten `src/index.d.ts` covers all four exports using native browser API types. The build script copies it to `dist/` so it's included in the published package.

## Changes

- `src/index.d.ts` — New file with typed signatures for `getPermission`, `getUserMediaStream`, `isNavigatorPermissionsSupported`, `isNavigatorMediaDevicesSupported`
- `package.json` — Add `"types": "dist/index.d.ts"`, `"types"` condition in `exports` map (first, as TypeScript requires), update `build` script to copy `.d.ts` to `dist/`

## Test plan

- [x] All 19 tests pass
- [x] `yarn build` produces `dist/index.d.ts` alongside the JS bundles
- [x] Coverage 100%

Closes #77