### PR TITLE
feat(getPermission): add AbortSignal support for cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn add @untemps/user-permissions-utils
 
 `getPermission`:
 
-Returns a promise resolved when the permission is granted
+Returns a promise resolved when the permission is granted. Accepts an optional `signal` to cancel the pending wait.
 
 ```javascript
 import { getPermission } from '@untemps/user-permissions-utils'
@@ -29,6 +29,27 @@ const init = async () => {
         console.error(error)
     }
 }
+```
+
+To cancel a pending permission wait:
+
+```javascript
+import { getPermission } from '@untemps/user-permissions-utils'
+
+const controller = new AbortController()
+
+const init = async () => {
+    try {
+        await getPermission('microphone', { signal: controller.signal })
+        ...
+    } catch (error) {
+        if (error.name === 'AbortError') return
+        console.error(error)
+    }
+}
+
+// Cancel before the user responds to the permission dialog
+controller.abort()
 ```
 
 `getUserMediaStream`:

--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -1,5 +1,7 @@
 import getPermission from '../getPermission'
 
+const flushMicrotasks = () => Promise.resolve()
+
 describe('getPermission', () => {
 	describe('navigator.permissions is not implemented', () => {
 		beforeAll(() => {
@@ -123,7 +125,7 @@ describe('getPermission', () => {
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				const promise = getPermission('microphone', { signal: controller.signal })
-				await Promise.resolve()
+				await flushMicrotasks()
 				controller.abort(reason)
 
 				await expect(promise).rejects.toBe(reason)
@@ -153,7 +155,7 @@ describe('getPermission', () => {
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				const promise = getPermission('microphone', { signal: controller.signal })
-				await Promise.resolve() // flush microtasks so query resolves and listeners register
+				await flushMicrotasks()
 				controller.abort()
 
 				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
@@ -186,7 +188,7 @@ describe('getPermission', () => {
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				const promise = getPermission('microphone', { signal: controller.signal })
-				await Promise.resolve() // flush microtasks so query resolves and listeners register
+				await flushMicrotasks()
 				controller.abort()
 
 				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })

--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -82,5 +82,116 @@ describe('getPermission', () => {
 			})
 			await expect(getPermission()).rejects.toEqual(new Error('ERR'))
 		})
+
+		describe('AbortSignal', () => {
+			it('rejects immediately when signal is already aborted', async () => {
+				const controller = new AbortController()
+				controller.abort()
+				await expect(getPermission('microphone', { signal: controller.signal })).rejects.toMatchObject({
+					name: 'AbortError',
+				})
+			})
+
+			it('rejects with custom reason when signal is already aborted with reason', async () => {
+				const controller = new AbortController()
+				const reason = new DOMException('Custom reason', 'AbortError')
+				controller.abort(reason)
+				await expect(getPermission('microphone', { signal: controller.signal })).rejects.toBe(reason)
+			})
+
+			it('rejects with custom reason when aborted with reason during query resolution', async () => {
+				const controller = new AbortController()
+				const reason = new DOMException('Custom reason', 'AbortError')
+				const status = new PermissionStatus()
+				status.state = 'prompt'
+				status.addEventListener = vi.fn()
+				status.removeEventListener = vi.fn()
+				mockPermissionsQuery.mockImplementationOnce(() => {
+					controller.abort(reason)
+					return Promise.resolve(status)
+				})
+				await expect(getPermission('microphone', { signal: controller.signal })).rejects.toBe(reason)
+			})
+
+			it('rejects with custom reason when aborted with reason while waiting in prompt state', async () => {
+				const controller = new AbortController()
+				const reason = new DOMException('Custom reason', 'AbortError')
+				const status = new PermissionStatus()
+				status.state = 'prompt'
+				status.addEventListener = vi.fn()
+				status.removeEventListener = vi.fn()
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				const promise = getPermission('microphone', { signal: controller.signal })
+				await Promise.resolve()
+				controller.abort(reason)
+
+				await expect(promise).rejects.toBe(reason)
+			})
+
+			it('resolves and cleans up abort listener when permission granted via onChange', async () => {
+				const controller = new AbortController()
+				const removeAbortSpy = vi.spyOn(controller.signal, 'removeEventListener')
+				const status = new PermissionStatus()
+				status.state = 'prompt'
+				status.addEventListener = vi.fn((e, cb) => {
+					cb({ target: { state: 'granted' } })
+				})
+				status.removeEventListener = vi.fn()
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				await expect(getPermission('microphone', { signal: controller.signal })).resolves.toBe('granted')
+				expect(removeAbortSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+			})
+
+			it('rejects when signal is aborted while waiting in prompt state', async () => {
+				const controller = new AbortController()
+				const status = new PermissionStatus()
+				status.state = 'prompt'
+				status.addEventListener = vi.fn()
+				status.removeEventListener = vi.fn()
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				const promise = getPermission('microphone', { signal: controller.signal })
+				await Promise.resolve() // flush microtasks so query resolves and listeners register
+				controller.abort()
+
+				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+			})
+
+			it('rejects when signal is aborted during query resolution (race condition)', async () => {
+				const controller = new AbortController()
+				const status = new PermissionStatus()
+				status.state = 'prompt'
+				status.addEventListener = vi.fn()
+				status.removeEventListener = vi.fn()
+				// Abort synchronously inside the mock so signal is aborted when await resolves
+				mockPermissionsQuery.mockImplementationOnce(() => {
+					controller.abort()
+					return Promise.resolve(status)
+				})
+
+				await expect(getPermission('microphone', { signal: controller.signal })).rejects.toMatchObject({
+					name: 'AbortError',
+				})
+			})
+
+			it('cleans up onChange listener when aborted', async () => {
+				const controller = new AbortController()
+				const status = new PermissionStatus()
+				status.state = 'prompt'
+				const mockRemoveEventListener = vi.fn()
+				status.addEventListener = vi.fn()
+				status.removeEventListener = mockRemoveEventListener
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				const promise = getPermission('microphone', { signal: controller.signal })
+				await Promise.resolve() // flush microtasks so query resolves and listeners register
+				controller.abort()
+
+				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+				expect(mockRemoveEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+			})
+		})
 	})
 })

--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -11,17 +11,13 @@ export default async (permissionName, { signal } = {}) => {
 		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
 	}
 
-	if (signal?.aborted) {
-		throw signal.reason
-	}
+	signal?.throwIfAborted()
 
 	const permissionStatus = await navigator.permissions.query({ name: permissionName })
 
 	if (permissionStatus.state === 'prompt') {
 		return new Promise((resolve, reject) => {
-			if (signal?.aborted) {
-				return reject(signal.reason)
-			}
+			signal?.throwIfAborted()
 
 			const onChange = (event) => {
 				permissionStatus.removeEventListener('change', onChange)

--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -3,26 +3,43 @@ import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
 /**
  * Returns a promise resolved when the permission is granted by the user
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
+ * @param options.signal            Optional AbortSignal to cancel the pending permission wait
  * @returns {Promise}
  */
-export default async (permissionName) => {
+export default async (permissionName, { signal } = {}) => {
 	if (!isNavigatorPermissionsSupported()) {
 		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+	}
+
+	if (signal?.aborted) {
+		throw signal.reason
 	}
 
 	const permissionStatus = await navigator.permissions.query({ name: permissionName })
 
 	if (permissionStatus.state === 'prompt') {
 		return new Promise((resolve, reject) => {
+			if (signal?.aborted) {
+				return reject(signal.reason)
+			}
+
 			const onChange = (event) => {
 				permissionStatus.removeEventListener('change', onChange)
+				signal?.removeEventListener('abort', onAbort)
 				try {
 					resolve(resolveOrRejectBasedOnState(event.target.state))
 				} catch (error) {
 					reject(error)
 				}
 			}
+
+			const onAbort = () => {
+				permissionStatus.removeEventListener('change', onChange)
+				reject(signal.reason)
+			}
+
 			permissionStatus.addEventListener('change', onChange)
+			signal?.addEventListener('abort', onAbort, { once: true })
 		})
 	}
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,7 @@
-export declare function getPermission(permissionName: PermissionName): Promise<PermissionState>
+export declare function getPermission(
+	permissionName: PermissionName,
+	options?: { signal?: AbortSignal }
+): Promise<PermissionState>
 export declare function getUserMediaStream(
 	permissionName: PermissionName,
 	constraints: MediaStreamConstraints


### PR DESCRIPTION
## Summary

`getPermission` had no cancellation mechanism — once called, the pending promise and its `change` event listener could not be cancelled. In UI contexts (component unmount, navigation change), this leaks listeners and risks calling callbacks on unmounted components. `AbortSignal` is the standard Web API pattern for cancellation.

## Changes

- `src/getPermission.js` — Accept optional `{ signal }` parameter; check `signal.aborted` at three points (before query, race condition inside Promise, and via `onAbort` listener during prompt state); cross-cleanup between `onChange` and `onAbort` listeners
- `src/index.d.ts` — Update `getPermission` signature with `options?: { signal?: AbortSignal }`
- `README.md` — Add usage example with `AbortController`

## Notes

`signal.reason` is used directly without a `?? DOMException` fallback — the WHATWG spec guarantees `reason` is always set when `abort()` is called (no-reason calls default to a `DOMException` automatically).

## Test plan

- [x] 27/27 tests pass (8 new AbortSignal tests)
- [x] Coverage 100% (statements, branches, functions, lines)
- [x] Build passes

Closes #78