### PR TITLE
fix!(types): narrow getPermission return type to Promise<'granted'>

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,7 @@
 export declare function getPermission(
 	permissionName: PermissionName,
 	options?: { signal?: AbortSignal }
-): Promise<PermissionState>
+): Promise<'granted'>
 export declare function getUserMediaStream(
 	permissionName: PermissionName,
 	constraints: MediaStreamConstraints


### PR DESCRIPTION
## Summary

`getPermission` was typed as returning `Promise<PermissionState>`, implying it could resolve with `'denied'` or `'prompt'`. In practice, `'denied'` throws a `DOMException` and `'prompt'` keeps the promise pending — the function exclusively resolves with `'granted'`. The overly broad type was misleading TypeScript consumers.

## Changes

- `src/index.d.ts` — `Promise<PermissionState>` → `Promise<'granted'>` on `getPermission`

## ⚠️ Breaking changes

- **`getPermission` return type**: TypeScript consumers who assigned the resolved value to a variable typed as `PermissionState` and branched on `'denied'` or `'prompt'` will get a compile-time error.
- Migration: remove those branches — they are unreachable given the function's actual behavior.

## Test plan

- [x] All 27 tests pass
- [x] Build passes
- [x] Coverage 100%

Closes #92
Closes #100