### PR TITLE
fix(test): correct it() descriptions in guard test files

### DIFF
--- a/src/__tests__/isNavigatorMediaDevicesSupported.test.js
+++ b/src/__tests__/isNavigatorMediaDevicesSupported.test.js
@@ -51,7 +51,7 @@ describe('isNavigatorMediaDevicesSupported', () => {
 			global.MediaDevices.mockReset()
 		})
 
-		it('returns false as permissions is not supported', async () => {
+		it('returns true as mediaDevices is supported', async () => {
 			expect(isNavigatorMediaDevicesSupported()).toBeTruthy()
 		})
 	})

--- a/src/__tests__/isNavigatorPermissionsSupported.test.js
+++ b/src/__tests__/isNavigatorPermissionsSupported.test.js
@@ -33,7 +33,7 @@ describe('isNavigatorPermissionsSupported', () => {
 			global.Permissions.mockReset()
 		})
 
-		it('returns false as permissions is not supported', async () => {
+		it('returns true as permissions is supported', async () => {
 			expect(isNavigatorPermissionsSupported()).toBeTruthy()
 		})
 	})


### PR DESCRIPTION
## Summary

Both guard test files had `it('returns false as permissions is not supported', ...)` inside their "implemented" describe blocks, where the assertion was actually `toBeTruthy()`. The description contradicted the assertion.

## Changes

- `src/__tests__/isNavigatorPermissionsSupported.test.js` — rename to `'returns true as permissions is supported'`
- `src/__tests__/isNavigatorMediaDevicesSupported.test.js` — rename to `'returns true as mediaDevices is supported'`

## Test plan

- [x] All 27 tests pass
- [x] Coverage 100%

Closes #93