### PR TITLE
chore(tooling): fix prettier glob to cover root-level JS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"build": "vite build && cp src/index.d.ts dist/index.d.ts",
-		"prettier": "prettier \"*/**/*.js\" --ignore-path ./.prettierignore --write",
+		"prettier": "prettier \"./**/*.js\" --ignore-path ./.prettierignore --write",
 		"prepare": "husky"
 	}
 }


### PR DESCRIPTION
## Summary

The `prettier` script used `"*/**/*.js"` which matches files one directory level deep and below, missing root-level files like `vite.config.js`. Changed to `"./**/*.js"` to include all JS files recursively from the project root. `.prettierignore` already excludes `dist/`, `coverage/`, and `node_modules/`.

## Changes

- `package.json` — `"*/**/*.js"` → `"./**/*.js"` in the `prettier` script

## Test plan

- [x] `yarn prettier` now formats `vite.config.js` (verified: appears in output)
- [x] All 27 tests pass
- [x] Coverage 100%

Closes #95