### PR TITLE
docs: Remove dead else branch from getUserMediaStream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,10 @@ import { getUserMediaStream } from '@untemps/user-permissions-utils'
 
 const init = async () => {
     try {
-    	const stream = await getUserMediaStream('microphone', { audio: true })
-    	if(!!stream) {
-    	    const audioContext = new AudioContext()
-    	    const streamNode = audioContext.createMediaStreamSource(stream)
-            ...
-    	} else {
-    	    console.error('Stream is not available')
-    	}
+        const stream = await getUserMediaStream('microphone', { audio: true })
+        const audioContext = new AudioContext()
+        const streamNode = audioContext.createMediaStreamSource(stream)
+        ...
     } catch (error) {
         console.error(error)
     }


### PR DESCRIPTION
## Summary

The `getUserMediaStream` README example contained an `if(!!stream)/else` guard suggesting a stream could be `null`. `navigator.mediaDevices.getUserMedia()` always either resolves with a `MediaStream` or rejects — it never resolves with a nullish value. The `else` branch was dead code that misled consumers.

## Changes

- `README.md` — Remove `if(!!stream)/else` wrapper, use the stream directly. The `catch` block already handles all error cases.

## Test plan

- [x] All 27 tests pass
- [x] Coverage 100%

Closes #97