### PR TITLE
test(get-user-media-stream): Remove unused mock setup in mediaDevices guard test

### DIFF
--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -42,9 +42,6 @@ describe('getUserMediaStream', () => {
 			})
 
 			it('rejects promise', async () => {
-				const status = new PermissionStatus()
-				status.state = 'prompt'
-				mockPermissionsQuery.mockResolvedValueOnce(status)
 				await expect(getUserMediaStream()).rejects.toMatchObject({
 					message: 'Navigator API: permissions or Navigator API: mediaDevices not supported',
 					name: 'NOT_SUPPORTED_ERR',


### PR DESCRIPTION
## Summary

The "rejects promise" test inside the "navigator.mediaDevices is not implemented" block was setting up a `PermissionStatus` mock and calling `mockPermissionsQuery.mockResolvedValueOnce(status)` — which were never consumed. `getUserMediaStream` throws at the `isNavigatorMediaDevicesSupported()` guard before reaching `getPermission`, making this setup dead code that falsely implied `getPermission` was called.

## Changes

- `src/__tests__/getUserMediaStream.test.js` — Remove `status` construction and `mockPermissionsQuery.mockResolvedValueOnce(status)` from the mediaDevices guard test

## Test plan

- [x] All 27 tests pass
- [x] Coverage 100%

Closes #98