### PR TITLE
feat(get-user-media-stream): Add AbortSignal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ controller.abort()
 
 `getUserMediaStream`:
 
-Returns a promise resolved when the permission is granted and the stream is retrieved
+Returns a promise resolved when the permission is granted and the stream is retrieved. Accepts an optional `signal` to cancel the entire operation.
 
 ```javascript
 import { getUserMediaStream } from '@untemps/user-permissions-utils'
@@ -69,6 +69,27 @@ const init = async () => {
         console.error(error)
     }
 }
+```
+
+To cancel a pending stream acquisition:
+
+```javascript
+import { getUserMediaStream } from '@untemps/user-permissions-utils'
+
+const controller = new AbortController()
+
+const init = async () => {
+    try {
+        const stream = await getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+        ...
+    } catch (error) {
+        if (error.name === 'AbortError') return
+        console.error(error)
+    }
+}
+
+// Cancel the operation at any point (permission wait or stream acquisition)
+controller.abort()
 ```
 
 `isNavigatorPermissionsSupported`:

--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -1,6 +1,5 @@
 import getPermission from '../getPermission'
-
-const flushMicrotasks = () => Promise.resolve()
+import { flushMicrotasks } from './testUtils'
 
 describe('getPermission', () => {
 	describe('navigator.permissions is not implemented', () => {

--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -127,6 +127,64 @@ describe('getUserMediaStream', () => {
 				})
 				await expect(getUserMediaStream()).rejects.toEqual(new Error('ERR'))
 			})
+
+			describe('AbortSignal', () => {
+				const flushMicrotasks = () => Promise.resolve()
+
+				it('rejects immediately when signal is already aborted', async () => {
+					const controller = new AbortController()
+					controller.abort()
+					await expect(
+						getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					).rejects.toMatchObject({
+						name: 'AbortError',
+					})
+				})
+
+				it('rejects when signal is aborted during permission wait', async () => {
+					const controller = new AbortController()
+					const status = new PermissionStatus()
+					status.state = 'prompt'
+					status.addEventListener = vi.fn()
+					status.removeEventListener = vi.fn()
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+
+					const promise = getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					await flushMicrotasks()
+					controller.abort()
+
+					await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+				})
+
+				it('rejects when signal is aborted after permission granted but before getUserMedia', async () => {
+					const controller = new AbortController()
+					const status = new PermissionStatus()
+					status.state = 'granted'
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						controller.abort()
+						return Promise.resolve(status)
+					})
+
+					await expect(
+						getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					).rejects.toMatchObject({
+						name: 'AbortError',
+					})
+					expect(mockMediaDevicesGetUserMedia).not.toHaveBeenCalled()
+				})
+
+				it('resolves with stream when signal is provided but not aborted', async () => {
+					const controller = new AbortController()
+					const status = new PermissionStatus()
+					status.state = 'granted'
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+					mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
+
+					await expect(
+						getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					).resolves.toBe('foo')
+				})
+			})
 		})
 	})
 })

--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -1,4 +1,5 @@
 import getUserMediaStream from '../getUserMediaStream'
+import { flushMicrotasks } from './testUtils'
 
 describe('getUserMediaStream', () => {
 	describe('navigator.permissions is not implemented', () => {
@@ -129,8 +130,6 @@ describe('getUserMediaStream', () => {
 			})
 
 			describe('AbortSignal', () => {
-				const flushMicrotasks = () => Promise.resolve()
-
 				it('rejects immediately when signal is already aborted', async () => {
 					const controller = new AbortController()
 					controller.abort()

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -1,0 +1,1 @@
+export const flushMicrotasks = () => Promise.resolve()

--- a/src/getPermission.js
+++ b/src/getPermission.js
@@ -3,7 +3,8 @@ import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
 /**
  * Returns a promise resolved when the permission is granted by the user
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
- * @param options.signal            Optional AbortSignal to cancel the pending permission wait
+ * @param {Object} [options]
+ * @param {AbortSignal} [options.signal]  Optional AbortSignal to cancel the pending permission wait
  * @returns {Promise}
  */
 export default async (permissionName, { signal } = {}) => {

--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -6,7 +6,8 @@ import getPermission from './getPermission'
  * Returns a promise resolved when the permission is granted by the user and the stream is retrieved
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
  * @param mediaStreamConstraints    Constraints object. @see https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
- * @param options.signal            Optional AbortSignal to cancel the operation
+ * @param {Object} [options]
+ * @param {AbortSignal} [options.signal]  Optional AbortSignal to cancel the operation
  * @returns {Promise}
  */
 export default async (permissionName, mediaStreamConstraints, { signal } = {}) => {

--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -6,9 +6,10 @@ import getPermission from './getPermission'
  * Returns a promise resolved when the permission is granted by the user and the stream is retrieved
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
  * @param mediaStreamConstraints    Constraints object. @see https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
+ * @param options.signal            Optional AbortSignal to cancel the operation
  * @returns {Promise}
  */
-export default async (permissionName, mediaStreamConstraints) => {
+export default async (permissionName, mediaStreamConstraints, { signal } = {}) => {
 	if (!isNavigatorPermissionsSupported() || !isNavigatorMediaDevicesSupported()) {
 		throw new DOMException(
 			'Navigator API: permissions or Navigator API: mediaDevices not supported',
@@ -16,6 +17,7 @@ export default async (permissionName, mediaStreamConstraints) => {
 		)
 	}
 
-	await getPermission(permissionName)
+	await getPermission(permissionName, { signal })
+	signal?.throwIfAborted()
 	return navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,8 @@ export declare function getPermission(
 ): Promise<'granted'>
 export declare function getUserMediaStream(
 	permissionName: PermissionName,
-	constraints: MediaStreamConstraints
+	constraints: MediaStreamConstraints,
+	options?: { signal?: AbortSignal }
 ): Promise<MediaStream>
 export declare function isNavigatorPermissionsSupported(): boolean
 export declare function isNavigatorMediaDevicesSupported(): boolean


### PR DESCRIPTION
## Summary

`getUserMediaStream` could not be cancelled — aborting during the permission wait left the potential `getUserMedia` call unguarded. A consistent API requires full cancellation of the entire operation.

## Changes

- `src/getUserMediaStream.js` — Accept optional `{ signal }` as third parameter; forward to `getPermission` (permission-wait phase); check `signal?.throwIfAborted()` before `getUserMedia` (gap between permission granted and stream acquisition)
- `src/index.d.ts` — Add `options?: { signal?: AbortSignal }` to `getUserMediaStream` signature
- `README.md` — Document the signal parameter with a usage example

## Design note

Signal is **not** spread into `MediaStreamConstraints` — `signal` is not a standard `MediaStreamConstraints` property and would cause TypeScript errors. The `throwIfAborted()` guard covers the abort-between-steps window instead.

## Test plan

- [x] 31/31 tests pass (4 new AbortSignal tests)
- [x] Coverage 100%
- [x] Verifies: already-aborted, aborted during permission wait, aborted between permission and getUserMedia (getUserMedia not called), resolves normally when signal is active

Closes #99