### PR TITLE
test: Extract shared mock setup helpers to testUtils

### DIFF
--- a/src/__tests__/getPermission.test.js
+++ b/src/__tests__/getPermission.test.js
@@ -1,5 +1,5 @@
 import getPermission from '../getPermission'
-import { flushMicrotasks } from './testUtils'
+import { flushMicrotasks, setupPermissionsMock, teardownPermissionsMock } from './testUtils'
 
 describe('getPermission', () => {
 	describe('navigator.permissions is not implemented', () => {
@@ -18,24 +18,9 @@ describe('getPermission', () => {
 	describe('navigator.permissions is implemented', () => {
 		const mockPermissionsQuery = vi.fn()
 
-		beforeAll(() => {
-			global.PermissionStatus = vi.fn(function () {
-				return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
-			})
-			global.Permissions = vi.fn(function () {
-				return { query: mockPermissionsQuery }
-			})
-			global.navigator.permissions = new Permissions()
-		})
-
-		beforeEach(() => {
-			mockPermissionsQuery.mockReset()
-		})
-
-		afterAll(() => {
-			global.PermissionStatus.mockReset()
-			global.Permissions.mockReset()
-		})
+		beforeAll(() => setupPermissionsMock(mockPermissionsQuery))
+		beforeEach(() => mockPermissionsQuery.mockReset())
+		afterAll(teardownPermissionsMock)
 
 		it('rejects promise since user has previously denied permissions', async () => {
 			const status = new PermissionStatus()

--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -1,5 +1,11 @@
 import getUserMediaStream from '../getUserMediaStream'
-import { flushMicrotasks } from './testUtils'
+import {
+	flushMicrotasks,
+	setupPermissionsMock,
+	teardownPermissionsMock,
+	setupMediaDevicesMock,
+	teardownMediaDevicesMock,
+} from './testUtils'
 
 describe('getUserMediaStream', () => {
 	describe('navigator.permissions is not implemented', () => {
@@ -18,24 +24,9 @@ describe('getUserMediaStream', () => {
 	describe('navigator.permissions is implemented', () => {
 		const mockPermissionsQuery = vi.fn()
 
-		beforeAll(() => {
-			global.PermissionStatus = vi.fn(function () {
-				return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
-			})
-			global.Permissions = vi.fn(function () {
-				return { query: mockPermissionsQuery }
-			})
-			global.navigator.permissions = new Permissions()
-		})
-
-		beforeEach(() => {
-			mockPermissionsQuery.mockReset()
-		})
-
-		afterAll(() => {
-			global.PermissionStatus.mockReset()
-			global.Permissions.mockReset()
-		})
+		beforeAll(() => setupPermissionsMock(mockPermissionsQuery))
+		beforeEach(() => mockPermissionsQuery.mockReset())
+		afterAll(teardownPermissionsMock)
 
 		describe('navigator.mediaDevices is not implemented', () => {
 			beforeAll(() => {
@@ -53,20 +44,9 @@ describe('getUserMediaStream', () => {
 		describe('navigator.mediaDevices is implemented', () => {
 			const mockMediaDevicesGetUserMedia = vi.fn()
 
-			beforeAll(() => {
-				global.MediaDevices = vi.fn(function () {
-					return { getUserMedia: mockMediaDevicesGetUserMedia }
-				})
-				global.navigator.mediaDevices = new MediaDevices()
-			})
-
-			beforeEach(() => {
-				mockMediaDevicesGetUserMedia.mockReset()
-			})
-
-			afterAll(() => {
-				global.MediaDevices.mockReset()
-			})
+			beforeAll(() => setupMediaDevicesMock(mockMediaDevicesGetUserMedia))
+			beforeEach(() => mockMediaDevicesGetUserMedia.mockReset())
+			afterAll(teardownMediaDevicesMock)
 
 			it('rejects promise since user has previously denied permissions', async () => {
 				const status = new PermissionStatus()

--- a/src/__tests__/isNavigatorMediaDevicesSupported.test.js
+++ b/src/__tests__/isNavigatorMediaDevicesSupported.test.js
@@ -1,10 +1,5 @@
 import isNavigatorMediaDevicesSupported from '../isNavigatorMediaDevicesSupported'
-import {
-	setupPermissionsMock,
-	teardownPermissionsMock,
-	setupMediaDevicesMock,
-	teardownMediaDevicesMock,
-} from './testUtils'
+import { setupPermissionsMock, setupMediaDevicesMock, teardownPermissionsAndMediaDevicesMock } from './testUtils'
 
 describe('isNavigatorMediaDevicesSupported', () => {
 	describe('navigator.permissions is not implemented', () => {
@@ -39,10 +34,7 @@ describe('isNavigatorMediaDevicesSupported', () => {
 			mockPermissionsQuery.mockReset()
 			mockMediaDevicesGetUserMedia.mockReset()
 		})
-		afterAll(() => {
-			teardownPermissionsMock()
-			teardownMediaDevicesMock()
-		})
+		afterAll(teardownPermissionsAndMediaDevicesMock)
 
 		it('returns true as mediaDevices is supported', async () => {
 			expect(isNavigatorMediaDevicesSupported()).toBeTruthy()

--- a/src/__tests__/isNavigatorMediaDevicesSupported.test.js
+++ b/src/__tests__/isNavigatorMediaDevicesSupported.test.js
@@ -1,4 +1,10 @@
 import isNavigatorMediaDevicesSupported from '../isNavigatorMediaDevicesSupported'
+import {
+	setupPermissionsMock,
+	teardownPermissionsMock,
+	setupMediaDevicesMock,
+	teardownMediaDevicesMock,
+} from './testUtils'
 
 describe('isNavigatorMediaDevicesSupported', () => {
 	describe('navigator.permissions is not implemented', () => {
@@ -26,29 +32,16 @@ describe('isNavigatorMediaDevicesSupported', () => {
 		const mockMediaDevicesGetUserMedia = vi.fn()
 
 		beforeAll(() => {
-			global.PermissionStatus = vi.fn(function () {
-				return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
-			})
-			global.Permissions = vi.fn(function () {
-				return { query: mockPermissionsQuery }
-			})
-			global.navigator.permissions = new Permissions()
-
-			global.MediaDevices = vi.fn(function () {
-				return { getUserMedia: mockMediaDevicesGetUserMedia }
-			})
-			global.navigator.mediaDevices = new MediaDevices()
+			setupPermissionsMock(mockPermissionsQuery)
+			setupMediaDevicesMock(mockMediaDevicesGetUserMedia)
 		})
-
 		beforeEach(() => {
 			mockPermissionsQuery.mockReset()
 			mockMediaDevicesGetUserMedia.mockReset()
 		})
-
 		afterAll(() => {
-			global.PermissionStatus.mockReset()
-			global.Permissions.mockReset()
-			global.MediaDevices.mockReset()
+			teardownPermissionsMock()
+			teardownMediaDevicesMock()
 		})
 
 		it('returns true as mediaDevices is supported', async () => {

--- a/src/__tests__/isNavigatorPermissionsSupported.test.js
+++ b/src/__tests__/isNavigatorPermissionsSupported.test.js
@@ -1,4 +1,5 @@
 import isNavigatorPermissionsSupported from '../isNavigatorPermissionsSupported'
+import { setupPermissionsMock, teardownPermissionsMock } from './testUtils'
 
 describe('isNavigatorPermissionsSupported', () => {
 	describe('navigator.permissions is not implemented', () => {
@@ -14,24 +15,9 @@ describe('isNavigatorPermissionsSupported', () => {
 	describe('navigator.permissions is implemented', () => {
 		const mockPermissionsQuery = vi.fn()
 
-		beforeAll(() => {
-			global.PermissionStatus = vi.fn(function () {
-				return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
-			})
-			global.Permissions = vi.fn(function () {
-				return { query: mockPermissionsQuery }
-			})
-			global.navigator.permissions = new Permissions()
-		})
-
-		beforeEach(() => {
-			mockPermissionsQuery.mockReset()
-		})
-
-		afterAll(() => {
-			global.PermissionStatus.mockReset()
-			global.Permissions.mockReset()
-		})
+		beforeAll(() => setupPermissionsMock(mockPermissionsQuery))
+		beforeEach(() => mockPermissionsQuery.mockReset())
+		afterAll(teardownPermissionsMock)
 
 		it('returns true as permissions is supported', async () => {
 			expect(isNavigatorPermissionsSupported()).toBeTruthy()

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -1,1 +1,27 @@
 export const flushMicrotasks = () => Promise.resolve()
+
+export const setupPermissionsMock = (mockQuery) => {
+	global.PermissionStatus = vi.fn(function () {
+		return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
+	})
+	global.Permissions = vi.fn(function () {
+		return { query: mockQuery }
+	})
+	global.navigator.permissions = new Permissions()
+}
+
+export const teardownPermissionsMock = () => {
+	global.PermissionStatus.mockReset()
+	global.Permissions.mockReset()
+}
+
+export const setupMediaDevicesMock = (mockGetUserMedia) => {
+	global.MediaDevices = vi.fn(function () {
+		return { getUserMedia: mockGetUserMedia }
+	})
+	global.navigator.mediaDevices = new MediaDevices()
+}
+
+export const teardownMediaDevicesMock = () => {
+	global.MediaDevices.mockReset()
+}

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -11,8 +11,9 @@ export const setupPermissionsMock = (mockQuery) => {
 }
 
 export const teardownPermissionsMock = () => {
-	global.PermissionStatus.mockReset()
-	global.Permissions.mockReset()
+	global.PermissionStatus = undefined
+	global.Permissions = undefined
+	global.navigator.permissions = undefined
 }
 
 export const setupMediaDevicesMock = (mockGetUserMedia) => {
@@ -23,5 +24,11 @@ export const setupMediaDevicesMock = (mockGetUserMedia) => {
 }
 
 export const teardownMediaDevicesMock = () => {
-	global.MediaDevices.mockReset()
+	global.MediaDevices = undefined
+	global.navigator.mediaDevices = undefined
+}
+
+export const teardownPermissionsAndMediaDevicesMock = () => {
+	teardownPermissionsMock()
+	teardownMediaDevicesMock()
 }


### PR DESCRIPTION
## Summary

`beforeAll`/`afterAll` mock setup for `PermissionStatus`, `Permissions`, and `MediaDevices` was copy-pasted across all four test files. Added four shared helpers to `testUtils.js` and replaced the duplicated blocks everywhere.

## Changes

- `src/__tests__/testUtils.js` — Add `setupPermissionsMock`, `teardownPermissionsMock`, `setupMediaDevicesMock`, `teardownMediaDevicesMock`
- `src/__tests__/getPermission.test.js` — Use shared helpers
- `src/__tests__/getUserMediaStream.test.js` — Use shared helpers
- `src/__tests__/isNavigatorPermissionsSupported.test.js` — Use shared helpers
- `src/__tests__/isNavigatorMediaDevicesSupported.test.js` — Use shared helpers

## Test plan

- [x] All 31 tests pass
- [x] Coverage 100% (47 statements, 16 functions)

Closes #113