### PR TITLE
fix: Resolve getUserMediaStream deadlock when permission is in 'prompt' state

### DIFF
--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -115,7 +115,7 @@ describe('getUserMediaStream', () => {
 					})
 				})
 
-				it('rejects when signal is aborted during permission wait', async () => {
+				it("rejects when signal is aborted after permission is 'prompt' but before getUserMedia", async () => {
 					const controller = new AbortController()
 					const status = new PermissionStatus()
 					status.state = 'prompt'

--- a/src/__tests__/getUserMediaStream.test.js
+++ b/src/__tests__/getUserMediaStream.test.js
@@ -1,6 +1,5 @@
 import getUserMediaStream from '../getUserMediaStream'
 import {
-	flushMicrotasks,
 	setupPermissionsMock,
 	teardownPermissionsMock,
 	setupMediaDevicesMock,
@@ -70,11 +69,10 @@ describe('getUserMediaStream', () => {
 			it('rejects promise since user has been prompted and has denied permissions', async () => {
 				const status = new PermissionStatus()
 				status.state = 'prompt'
-				status.addEventListener = vi.fn((e, cb) => {
-					cb({ target: { state: 'denied' } })
-				})
 				mockPermissionsQuery.mockResolvedValueOnce(status)
-				mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
+				mockMediaDevicesGetUserMedia.mockRejectedValueOnce(
+					new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+				)
 				await expect(getUserMediaStream()).rejects.toMatchObject({
 					message: 'Permission denied',
 					name: 'NOT_ALLOWED_ERR',
@@ -84,9 +82,6 @@ describe('getUserMediaStream', () => {
 			it('resolves promise with stream since user has been prompted and has granted permissions', async () => {
 				const status = new PermissionStatus()
 				status.state = 'prompt'
-				status.addEventListener = vi.fn((e, cb) => {
-					cb({ target: { state: 'granted' } })
-				})
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 				mockMediaDevicesGetUserMedia.mockResolvedValueOnce('foo')
 				await expect(getUserMediaStream()).resolves.toBe('foo')
@@ -124,15 +119,15 @@ describe('getUserMediaStream', () => {
 					const controller = new AbortController()
 					const status = new PermissionStatus()
 					status.state = 'prompt'
-					status.addEventListener = vi.fn()
-					status.removeEventListener = vi.fn()
-					mockPermissionsQuery.mockResolvedValueOnce(status)
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						controller.abort()
+						return Promise.resolve(status)
+					})
 
-					const promise = getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
-					await flushMicrotasks()
-					controller.abort()
-
-					await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+					await expect(
+						getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					).rejects.toMatchObject({ name: 'AbortError' })
+					expect(mockMediaDevicesGetUserMedia).not.toHaveBeenCalled()
 				})
 
 				it('rejects when signal is aborted after permission granted but before getUserMedia', async () => {

--- a/src/getUserMediaStream.js
+++ b/src/getUserMediaStream.js
@@ -1,6 +1,5 @@
 import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
 import isNavigatorMediaDevicesSupported from './isNavigatorMediaDevicesSupported'
-import getPermission from './getPermission'
 
 /**
  * Returns a promise resolved when the permission is granted by the user and the stream is retrieved
@@ -18,7 +17,14 @@ export default async (permissionName, mediaStreamConstraints, { signal } = {}) =
 		)
 	}
 
-	await getPermission(permissionName, { signal })
+	signal?.throwIfAborted()
+
+	const permissionStatus = await navigator.permissions.query({ name: permissionName })
+
+	if (permissionStatus.state === 'denied') {
+		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+	}
+
 	signal?.throwIfAborted()
 	return navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
 }


### PR DESCRIPTION
## Summary

Fixes a deadlock in `getUserMediaStream` when the permission state is `'prompt'` (first use). The internal `getPermission` call waited for a `change` event on the `PermissionStatus` object, but that event only fires after `getUserMedia` triggers the browser prompt — and `getUserMedia` was only called after `getPermission` resolved. Circular dependency → hang forever.

## Changes

- `src/getUserMediaStream.js` — Remove `getPermission` dependency. Query `navigator.permissions` directly, throw on `'denied'`, and call `getUserMedia` for both `'granted'` and `'prompt'` states. `getUserMedia` itself triggers the browser prompt and resolves with the stream.
- `src/__tests__/getUserMediaStream.test.js` — Update `'prompt'` state tests: remove `addEventListener` mocks (no longer used), mock `getUserMedia` rejection for the denied-after-prompt case, update abort test to abort inside the `permissions.query` mock.

## Test plan

- [ ] `yarn test:ci` — all 31 tests pass, 100% coverage
- [ ] `yarn build` — builds without errors
- [ ] `yarn prettier` — no formatting changes

Closes #118