### PR TITLE
feat: Add dev demo to test all library functions

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -266,10 +266,7 @@
 						<span class="support-label">camera</span>
 						<span class="support-value" id="permission-camera">—</span>
 					</div>
-					<div class="btn-row">
-						<button id="refresh-permissions-btn">refresh</button>
-					</div>
-					<p class="note" id="reset-hint" hidden>
+					<p class="note">
 						To reset permissions to 'prompt', click the lock icon in the browser address bar → reset permissions.
 					</p>
 				</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>user-permissions-utils — demo</title>
+		<style>
+			*,
+			*::before,
+			*::after {
+				box-sizing: border-box;
+				margin: 0;
+				padding: 0;
+			}
+
+			:root {
+				--bg: #0f1117;
+				--surface: #1a1d27;
+				--border: #2a2d3a;
+				--text: #e2e8f0;
+				--muted: #64748b;
+				--accent: #6366f1;
+				--success: #22c55e;
+				--error: #ef4444;
+				--warning: #f59e0b;
+				--radius: 8px;
+				--font: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+			}
+
+			body {
+				background: var(--bg);
+				color: var(--text);
+				font-family: var(--font);
+				font-size: 13px;
+				line-height: 1.6;
+				min-height: 100vh;
+				padding: 32px 16px;
+			}
+
+			.container {
+				max-width: 680px;
+				margin: 0 auto;
+				display: flex;
+				flex-direction: column;
+				gap: 16px;
+			}
+
+			header {
+				display: flex;
+				align-items: baseline;
+				gap: 12px;
+				padding-bottom: 16px;
+				border-bottom: 1px solid var(--border);
+			}
+
+			header h1 {
+				font-size: 15px;
+				font-weight: 600;
+				color: var(--text);
+			}
+
+			header span {
+				font-size: 11px;
+				color: var(--muted);
+			}
+
+			.card {
+				background: var(--surface);
+				border: 1px solid var(--border);
+				border-radius: var(--radius);
+				overflow: hidden;
+			}
+
+			.card-header {
+				padding: 10px 16px;
+				border-bottom: 1px solid var(--border);
+				font-size: 11px;
+				font-weight: 600;
+				text-transform: uppercase;
+				letter-spacing: 0.08em;
+				color: var(--muted);
+			}
+
+			.card-body {
+				padding: 16px;
+				display: flex;
+				flex-direction: column;
+				gap: 12px;
+			}
+
+			.support-row {
+				display: flex;
+				align-items: center;
+				gap: 10px;
+			}
+
+			.dot {
+				width: 7px;
+				height: 7px;
+				border-radius: 50%;
+				background: var(--muted);
+				flex-shrink: 0;
+			}
+
+			.dot.supported {
+				background: var(--success);
+			}
+
+			.dot.unsupported {
+				background: var(--error);
+			}
+
+			.support-label {
+				color: var(--muted);
+				min-width: 150px;
+			}
+
+			.support-value {
+				color: var(--text);
+			}
+
+			.btn-row {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				flex-wrap: wrap;
+			}
+
+			button {
+				background: transparent;
+				border: 1px solid var(--border);
+				color: var(--text);
+				font-family: var(--font);
+				font-size: 12px;
+				padding: 6px 14px;
+				border-radius: var(--radius);
+				cursor: pointer;
+				transition:
+					border-color 120ms,
+					color 120ms;
+			}
+
+			button:hover {
+				border-color: var(--accent);
+				color: var(--accent);
+			}
+
+			button:active {
+				opacity: 0.7;
+			}
+
+			button.danger {
+				border-color: #3a1f1f;
+				color: var(--error);
+			}
+
+			button.danger:hover {
+				border-color: var(--error);
+			}
+
+			.result {
+				font-size: 12px;
+				padding: 4px 0;
+				color: var(--muted);
+				min-height: 24px;
+			}
+
+			.result--success {
+				color: var(--success);
+			}
+
+			.result--error {
+				color: var(--error);
+			}
+
+			.result--warning {
+				color: var(--warning);
+			}
+
+			.result--pending {
+				color: var(--muted);
+			}
+
+			.log-entries {
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+				max-height: 200px;
+				overflow-y: auto;
+			}
+
+			.log-entry {
+				color: var(--muted);
+				font-size: 11px;
+				line-height: 1.5;
+			}
+
+			.log-entry .time {
+				color: #3a3d4a;
+				margin-right: 8px;
+			}
+
+			.log-entry.success .msg {
+				color: var(--success);
+			}
+
+			.log-entry.error .msg {
+				color: var(--error);
+			}
+
+			.log-entry.warning .msg {
+				color: var(--warning);
+			}
+
+			.empty-log {
+				color: #2a2d3a;
+				font-size: 11px;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<header>
+				<h1>user-permissions-utils</h1>
+				<span>dev demo</span>
+			</header>
+
+			<!-- API Support -->
+			<div class="card">
+				<div class="card-header">API Support</div>
+				<div class="card-body">
+					<div class="support-row">
+						<div class="dot" id="dot-permissions"></div>
+						<span class="support-label">Permissions API</span>
+						<span class="support-value" id="permissions-support">—</span>
+					</div>
+					<div class="support-row">
+						<div class="dot" id="dot-mediadevices"></div>
+						<span class="support-label">MediaDevices API</span>
+						<span class="support-value" id="mediadevices-support">—</span>
+					</div>
+				</div>
+			</div>
+
+			<!-- getPermission -->
+			<div class="card">
+				<div class="card-header">getPermission</div>
+				<div class="card-body">
+					<div class="btn-row">
+						<button data-action="getPermission" data-permission="microphone">microphone</button>
+						<button data-action="getPermission" data-permission="camera">camera</button>
+					</div>
+					<div class="result" id="permission-result"></div>
+				</div>
+			</div>
+
+			<!-- getUserMediaStream -->
+			<div class="card">
+				<div class="card-header">getUserMediaStream</div>
+				<div class="card-body">
+					<div class="btn-row">
+						<button data-action="getUserMediaStream" data-permission="microphone" data-constraints='{"audio":true}'>
+							microphone
+						</button>
+						<button data-action="getUserMediaStream" data-permission="camera" data-constraints='{"video":true}'>
+							camera
+						</button>
+						<button id="abort-btn" class="danger">abort</button>
+					</div>
+					<div class="result" id="stream-result"></div>
+				</div>
+			</div>
+
+			<!-- Log -->
+			<div class="card">
+				<div class="card-header">Log</div>
+				<div class="card-body">
+					<div class="log-entries" id="log">
+						<div class="empty-log">— no events yet —</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<script type="module" src="./main.js"></script>
+	</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -216,6 +216,12 @@
 				color: #2a2d3a;
 				font-size: 11px;
 			}
+
+			.note {
+				font-size: 11px;
+				color: var(--muted);
+				line-height: 1.5;
+			}
 		</style>
 	</head>
 	<body>
@@ -246,6 +252,7 @@
 			<div class="card">
 				<div class="card-header">getPermission</div>
 				<div class="card-body">
+					<p class="note">Reads current permission state — does not trigger a browser prompt. Updates live when state changes.</p>
 					<div class="btn-row">
 						<button data-action="getPermission" data-permission="microphone">microphone</button>
 						<button data-action="getPermission" data-permission="camera">camera</button>

--- a/demo/index.html
+++ b/demo/index.html
@@ -217,10 +217,8 @@
 				font-size: 11px;
 			}
 
-			.note {
-				font-size: 11px;
-				color: var(--muted);
-				line-height: 1.5;
+			.dot.prompt {
+				background: var(--warning);
 			}
 		</style>
 	</head>
@@ -252,12 +250,16 @@
 			<div class="card">
 				<div class="card-header">getPermission</div>
 				<div class="card-body">
-					<p class="note">Reads current permission state — does not trigger a browser prompt. Updates live when state changes.</p>
-					<div class="btn-row">
-						<button data-action="getPermission" data-permission="microphone">microphone</button>
-						<button data-action="getPermission" data-permission="camera">camera</button>
+					<div class="support-row">
+						<div class="dot" id="dot-permission-microphone"></div>
+						<span class="support-label">microphone</span>
+						<span class="support-value" id="permission-microphone">—</span>
 					</div>
-					<div class="result" id="permission-result"></div>
+					<div class="support-row">
+						<div class="dot" id="dot-permission-camera"></div>
+						<span class="support-label">camera</span>
+						<span class="support-value" id="permission-camera">—</span>
+					</div>
 				</div>
 			</div>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,7 +59,7 @@
 				color: var(--text);
 			}
 
-	.card {
+			.card {
 				background: var(--surface);
 				border: 1px solid var(--border);
 				border-radius: var(--radius);

--- a/demo/index.html
+++ b/demo/index.html
@@ -232,7 +232,6 @@
 		<div class="container">
 			<header>
 				<h1>user-permissions-utils</h1>
-				<span>dev demo</span>
 			</header>
 
 			<!-- API Support -->

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,12 +59,7 @@
 				color: var(--text);
 			}
 
-			header span {
-				font-size: 11px;
-				color: var(--muted);
-			}
-
-			.card {
+	.card {
 				background: var(--surface);
 				border: 1px solid var(--border);
 				border-radius: var(--radius);

--- a/demo/index.html
+++ b/demo/index.html
@@ -267,7 +267,7 @@
 						<span class="support-value" id="permission-camera">—</span>
 					</div>
 					<p class="note">
-						To reset permissions to 'prompt', click the lock icon in the browser address bar → reset permissions.
+						To reset permissions to 'prompt', click the lock or info icon in the browser address bar → reset permissions.
 					</p>
 				</div>
 			</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -220,6 +220,12 @@
 			.dot.prompt {
 				background: var(--warning);
 			}
+
+			.note {
+				font-size: 11px;
+				color: var(--muted);
+				line-height: 1.5;
+			}
 		</style>
 	</head>
 	<body>
@@ -260,6 +266,12 @@
 						<span class="support-label">camera</span>
 						<span class="support-value" id="permission-camera">—</span>
 					</div>
+					<div class="btn-row">
+						<button id="refresh-permissions-btn">refresh</button>
+					</div>
+					<p class="note" id="reset-hint" hidden>
+						To reset permissions to 'prompt', click the lock icon in the browser address bar → reset permissions.
+					</p>
 				</div>
 			</div>
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -4,6 +4,9 @@ let activeController = null
 let activeStream = null
 
 const WATCHED_PERMISSIONS = ['microphone', 'camera']
+const STATE_DOT_CLASS = { granted: 'supported', denied: 'unsupported', prompt: 'prompt' }
+const STATE_LOG_TYPE = { granted: 'success', denied: 'error', prompt: '' }
+const logEl = document.getElementById('log')
 
 document.addEventListener('DOMContentLoaded', () => {
 	initSupportStatus()
@@ -38,10 +41,7 @@ function initPermissionStates(permissionNames) {
 			renderPermissionState(name, status.state)
 			status.addEventListener('change', () => {
 				renderPermissionState(name, status.state)
-				log(
-					`permission "${name}" changed → ${status.state}`,
-					status.state === 'granted' ? 'success' : status.state === 'denied' ? 'error' : ''
-				)
+				log(`permission "${name}" changed → ${status.state}`, STATE_LOG_TYPE[status.state])
 			})
 		} catch (err) {
 			renderPermissionState(name, 'error')
@@ -53,7 +53,7 @@ function initPermissionStates(permissionNames) {
 function renderPermissionState(name, state) {
 	const dot = document.getElementById(`dot-permission-${name}`)
 	const label = document.getElementById(`permission-${name}`)
-	dot.className = `dot ${state === 'granted' ? 'supported' : state === 'denied' ? 'unsupported' : 'prompt'}`
+	dot.className = `dot ${STATE_DOT_CLASS[state]}`
 	label.textContent = state
 }
 
@@ -110,8 +110,6 @@ function setResult(id, text, type) {
 }
 
 function log(message, type = '') {
-	const logEl = document.getElementById('log')
-
 	const empty = logEl.querySelector('.empty-log')
 	if (empty) empty.remove()
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -3,9 +3,15 @@ import { isNavigatorPermissionsSupported, isNavigatorMediaDevicesSupported, getU
 let activeController = null
 let activeStream = null
 
+const WATCHED_PERMISSIONS = ['microphone', 'camera']
+
 document.addEventListener('DOMContentLoaded', () => {
 	initSupportStatus()
-	initPermissionStates(['microphone', 'camera'])
+	initPermissionStates(WATCHED_PERMISSIONS)
+
+	document
+		.getElementById('refresh-permissions-btn')
+		.addEventListener('click', () => refreshPermissionStates(WATCHED_PERMISSIONS))
 
 	document.querySelectorAll('[data-action="getUserMediaStream"]').forEach((btn) => {
 		btn.addEventListener('click', () =>
@@ -46,6 +52,22 @@ function initPermissionStates(permissionNames) {
 			log(`getPermission("${name}") ✗ ${err.name}: ${err.message}`, 'error')
 		}
 	})
+}
+
+async function refreshPermissionStates(permissionNames) {
+	const states = await Promise.all(
+		permissionNames.map(async (name) => {
+			const status = await navigator.permissions.query({ name })
+			renderPermissionState(name, status.state)
+			return status.state
+		})
+	)
+
+	const hint = document.getElementById('reset-hint')
+	const anyGrantedOrDenied = states.some((s) => s !== 'prompt')
+	hint.hidden = !anyGrantedOrDenied
+
+	log(`permissions refreshed — ${permissionNames.map((n, i) => `${n}: ${states[i]}`).join(', ')}`)
 }
 
 function renderPermissionState(name, state) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,0 +1,117 @@
+import {
+	isNavigatorPermissionsSupported,
+	isNavigatorMediaDevicesSupported,
+	getPermission,
+	getUserMediaStream,
+} from '../src/index.js'
+
+let activeController = null
+let activeStream = null
+
+document.addEventListener('DOMContentLoaded', () => {
+	initSupportStatus()
+
+	document.querySelectorAll('[data-action="getPermission"]').forEach((btn) => {
+		btn.addEventListener('click', () => handleGetPermission(btn.dataset.permission))
+	})
+
+	document.querySelectorAll('[data-action="getUserMediaStream"]').forEach((btn) => {
+		btn.addEventListener('click', () =>
+			handleGetUserMediaStream(btn.dataset.permission, JSON.parse(btn.dataset.constraints))
+		)
+	})
+
+	document.getElementById('abort-btn').addEventListener('click', handleAbort)
+})
+
+function initSupportStatus() {
+	const permissionsOk = isNavigatorPermissionsSupported()
+	const mediaDevicesOk = isNavigatorMediaDevicesSupported()
+
+	setSupport('permissions', permissionsOk)
+	setSupport('mediadevices', mediaDevicesOk)
+}
+
+function setSupport(key, ok) {
+	document.getElementById(`dot-${key}`).classList.add(ok ? 'supported' : 'unsupported')
+	document.getElementById(`${key}-support`).textContent = ok ? 'supported' : 'not supported'
+}
+
+async function handleGetPermission(permissionName) {
+	setResult('permission-result', `querying ${permissionName}…`, 'pending')
+	log(`getPermission("${permissionName}") →`, 'pending')
+
+	try {
+		const state = await getPermission(permissionName)
+		setResult('permission-result', `→ ${state}`, 'success')
+		log(`getPermission("${permissionName}") → ${state}`, 'success')
+	} catch (err) {
+		setResult('permission-result', `→ ${err.name}: ${err.message}`, 'error')
+		log(`getPermission("${permissionName}") ✗ ${err.name}: ${err.message}`, 'error')
+	}
+}
+
+async function handleGetUserMediaStream(permissionName, constraints) {
+	stopActiveStream()
+	activeController = new AbortController()
+
+	setResult('stream-result', `acquiring ${permissionName} stream…`, 'pending')
+	log(`getUserMediaStream("${permissionName}") →`, 'pending')
+
+	try {
+		activeStream = await getUserMediaStream(permissionName, constraints, { signal: activeController.signal })
+
+		const tracks = activeStream.getTracks()
+		const kind = tracks[0]?.kind ?? 'unknown'
+		const label = `MediaStream — ${tracks.length} ${kind} track${tracks.length !== 1 ? 's' : ''} (id: ${activeStream.id.slice(0, 8)}…)`
+
+		setResult('stream-result', `→ ${label}`, 'success')
+		log(`getUserMediaStream("${permissionName}") → ${label}`, 'success')
+	} catch (err) {
+		if (err.name === 'AbortError') {
+			setResult('stream-result', '→ aborted', 'warning')
+			log(`getUserMediaStream("${permissionName}") — aborted`, 'warning')
+		} else {
+			setResult('stream-result', `→ ${err.name}: ${err.message}`, 'error')
+			log(`getUserMediaStream("${permissionName}") ✗ ${err.name}: ${err.message}`, 'error')
+		}
+	} finally {
+		activeController = null
+	}
+}
+
+function handleAbort() {
+	if (activeController) {
+		activeController.abort()
+	} else {
+		stopActiveStream()
+		setResult('stream-result', '→ no active stream', 'pending')
+		log('abort — no active operation', 'warning')
+	}
+}
+
+function stopActiveStream() {
+	if (activeStream) {
+		activeStream.getTracks().forEach((t) => t.stop())
+		activeStream = null
+	}
+}
+
+function setResult(id, text, type) {
+	const el = document.getElementById(id)
+	el.textContent = text
+	el.className = `result result--${type}`
+}
+
+function log(message, type = '') {
+	const logEl = document.getElementById('log')
+
+	const empty = logEl.querySelector('.empty-log')
+	if (empty) empty.remove()
+
+	const time = new Date().toLocaleTimeString()
+	const entry = document.createElement('div')
+	entry.className = `log-entry${type ? ` ${type}` : ''}`
+	entry.innerHTML = `<span class="time">${time}</span><span class="msg">${message}</span>`
+	logEl.prepend(entry)
+}

--- a/demo/main.js
+++ b/demo/main.js
@@ -125,5 +125,6 @@ function log(message, type = '') {
 	const entry = document.createElement('div')
 	entry.className = `log-entry${type ? ` ${type}` : ''}`
 	entry.innerHTML = `<span class="time">${time}</span><span class="msg">${message}</span>`
-	logEl.prepend(entry)
+	logEl.append(entry)
+	logEl.scrollTop = logEl.scrollHeight
 }

--- a/demo/main.js
+++ b/demo/main.js
@@ -9,10 +9,6 @@ document.addEventListener('DOMContentLoaded', () => {
 	initSupportStatus()
 	initPermissionStates(WATCHED_PERMISSIONS)
 
-	document
-		.getElementById('refresh-permissions-btn')
-		.addEventListener('click', () => refreshPermissionStates(WATCHED_PERMISSIONS))
-
 	document.querySelectorAll('[data-action="getUserMediaStream"]').forEach((btn) => {
 		btn.addEventListener('click', () =>
 			handleGetUserMediaStream(btn.dataset.permission, JSON.parse(btn.dataset.constraints))
@@ -52,22 +48,6 @@ function initPermissionStates(permissionNames) {
 			log(`getPermission("${name}") ✗ ${err.name}: ${err.message}`, 'error')
 		}
 	})
-}
-
-async function refreshPermissionStates(permissionNames) {
-	const states = await Promise.all(
-		permissionNames.map(async (name) => {
-			const status = await navigator.permissions.query({ name })
-			renderPermissionState(name, status.state)
-			return status.state
-		})
-	)
-
-	const hint = document.getElementById('reset-hint')
-	const anyGrantedOrDenied = states.some((s) => s !== 'prompt')
-	hint.hidden = !anyGrantedOrDenied
-
-	log(`permissions refreshed — ${permissionNames.map((n, i) => `${n}: ${states[i]}`).join(', ')}`)
 }
 
 function renderPermissionState(name, state) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,9 +1,4 @@
-import {
-	isNavigatorPermissionsSupported,
-	isNavigatorMediaDevicesSupported,
-	getPermission,
-	getUserMediaStream,
-} from '../src/index.js'
+import { isNavigatorPermissionsSupported, isNavigatorMediaDevicesSupported, getUserMediaStream } from '../src/index.js'
 
 let activeController = null
 let activeStream = null
@@ -37,18 +32,35 @@ function setSupport(key, ok) {
 	document.getElementById(`${key}-support`).textContent = ok ? 'supported' : 'not supported'
 }
 
+const permissionWatchers = {}
+
 async function handleGetPermission(permissionName) {
 	setResult('permission-result', `querying ${permissionName}…`, 'pending')
-	log(`getPermission("${permissionName}") →`, 'pending')
 
 	try {
-		const state = await getPermission(permissionName)
-		setResult('permission-result', `→ ${state}`, 'success')
-		log(`getPermission("${permissionName}") → ${state}`, 'success')
+		const status = await navigator.permissions.query({ name: permissionName })
+
+		showPermissionState(permissionName, status.state)
+
+		if (permissionWatchers[permissionName]) {
+			permissionWatchers[permissionName].removeEventListener('change', permissionWatchers[permissionName]._cb)
+		}
+
+		const onChange = () => showPermissionState(permissionName, status.state)
+		status._cb = onChange
+		status.addEventListener('change', onChange)
+		permissionWatchers[permissionName] = status
 	} catch (err) {
 		setResult('permission-result', `→ ${err.name}: ${err.message}`, 'error')
 		log(`getPermission("${permissionName}") ✗ ${err.name}: ${err.message}`, 'error')
 	}
+}
+
+function showPermissionState(permissionName, state) {
+	const type = state === 'granted' ? 'success' : state === 'denied' ? 'error' : 'warning'
+	const suffix = state === 'prompt' ? ' — no prompt yet (grant via getUserMediaStream)' : ''
+	setResult('permission-result', `→ ${state}${suffix}`, type)
+	log(`getPermission("${permissionName}") → ${state}`, type)
 }
 
 async function handleGetUserMediaStream(permissionName, constraints) {

--- a/demo/main.js
+++ b/demo/main.js
@@ -5,10 +5,7 @@ let activeStream = null
 
 document.addEventListener('DOMContentLoaded', () => {
 	initSupportStatus()
-
-	document.querySelectorAll('[data-action="getPermission"]').forEach((btn) => {
-		btn.addEventListener('click', () => handleGetPermission(btn.dataset.permission))
-	})
+	initPermissionStates(['microphone', 'camera'])
 
 	document.querySelectorAll('[data-action="getUserMediaStream"]').forEach((btn) => {
 		btn.addEventListener('click', () =>
@@ -32,35 +29,30 @@ function setSupport(key, ok) {
 	document.getElementById(`${key}-support`).textContent = ok ? 'supported' : 'not supported'
 }
 
-const permissionWatchers = {}
-
-async function handleGetPermission(permissionName) {
-	setResult('permission-result', `querying ${permissionName}…`, 'pending')
-
-	try {
-		const status = await navigator.permissions.query({ name: permissionName })
-
-		showPermissionState(permissionName, status.state)
-
-		if (permissionWatchers[permissionName]) {
-			permissionWatchers[permissionName].removeEventListener('change', permissionWatchers[permissionName]._cb)
+function initPermissionStates(permissionNames) {
+	permissionNames.forEach(async (name) => {
+		try {
+			const status = await navigator.permissions.query({ name })
+			renderPermissionState(name, status.state)
+			status.addEventListener('change', () => {
+				renderPermissionState(name, status.state)
+				log(
+					`permission "${name}" changed → ${status.state}`,
+					status.state === 'granted' ? 'success' : status.state === 'denied' ? 'error' : ''
+				)
+			})
+		} catch (err) {
+			renderPermissionState(name, 'error')
+			log(`getPermission("${name}") ✗ ${err.name}: ${err.message}`, 'error')
 		}
-
-		const onChange = () => showPermissionState(permissionName, status.state)
-		status._cb = onChange
-		status.addEventListener('change', onChange)
-		permissionWatchers[permissionName] = status
-	} catch (err) {
-		setResult('permission-result', `→ ${err.name}: ${err.message}`, 'error')
-		log(`getPermission("${permissionName}") ✗ ${err.name}: ${err.message}`, 'error')
-	}
+	})
 }
 
-function showPermissionState(permissionName, state) {
-	const type = state === 'granted' ? 'success' : state === 'denied' ? 'error' : 'warning'
-	const suffix = state === 'prompt' ? ' — no prompt yet (grant via getUserMediaStream)' : ''
-	setResult('permission-result', `→ ${state}${suffix}`, type)
-	log(`getPermission("${permissionName}") → ${state}`, type)
+function renderPermissionState(name, state) {
+	const dot = document.getElementById(`dot-permission-${name}`)
+	const label = document.getElementById(`permission-${name}`)
+	dot.className = `dot ${state === 'granted' ? 'supported' : state === 'denied' ? 'unsupported' : 'prompt'}`
+	label.textContent = state
 }
 
 async function handleGetUserMediaStream(permissionName, constraints) {

--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-	root: 'demo',
 	server: {
 		open: true,
 	},

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		]
 	},
 	"scripts": {
-		"dev": "vite --config vite.demo.config.js",
+		"dev": "vite demo --config demo/vite.config.js",
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"build": "vite build && cp src/index.d.ts dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 		]
 	},
 	"scripts": {
+		"dev": "vite --config vite.demo.config.js",
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"build": "vite build && cp src/index.d.ts dist/index.d.ts",

--- a/vite.demo.config.js
+++ b/vite.demo.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+	root: 'demo',
+	server: {
+		open: true,
+	},
+})


### PR DESCRIPTION
## Summary

Adds a minimal vanilla HTML/JS demo page served via Vite dev server. Covers all four exported functions and provides a live log of events.

## Changes

- `demo/index.html` — UI with sections for API support status, `getPermission`, `getUserMediaStream`, and a live log
- `demo/main.js` — wires up all buttons, handles streams and AbortController
- `vite.demo.config.js` — Vite config with `root: 'demo'` so `../src/index.js` resolves correctly
- `package.json` — adds `"dev": "vite --config vite.demo.config.js"` script

## Test plan

- [ ] `yarn dev` launches Vite at `localhost:5173` and opens the browser
- [ ] API support indicators reflect the actual browser state
- [ ] `getPermission` buttons trigger permission query and display state
- [ ] `getUserMediaStream` buttons acquire a real media stream
- [ ] Abort button cancels an in-progress `getUserMediaStream` call
- [ ] All results appear in the log with timestamps

## Notes

This branch is based on `main` (pre-merge of #118). Once #118 is merged, this branch should be rebased so `getUserMediaStream` with `'prompt'` state works correctly in the demo.