### PR TITLE
ci: Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,24 @@
-name: "Publish package"
+name: 'Publish'
 on:
     push:
         branches:
             - main
             - beta
+permissions:
+    contents: write
+    id-token: write
+    pull-requests: write
+    issues: write
 jobs:
-    release:
+    publish:
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            id-token: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
-                  node-version: '22'
+                  node-version: '24'
                   cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - run: yarn typecheck


### PR DESCRIPTION
## Résumé

Met à jour le workflow de publication (`.github/workflows/publish.yml`).

## Changements

- **Actions** : `actions/checkout@v4` → `@v6`, `actions/setup-node@v4` → `@v6`
- **Node** : `22` → `24`
- **Permissions** : remontées au niveau du workflow (au lieu du job) et élargies avec `pull-requests: write` + `issues: write` (utiles à semantic-release pour les commentaires/labels de release)
- **Renommage** : job `release` → `publish`, nom du workflow `Publish package` → `Publish`
- **Formatage** : conforme Prettier (4 espaces, guillemets simples)

## Notes

- Base **`beta`** (cohérent avec la branche ; `main` est en retard sur `beta`).
- Changement **CI uniquement** — aucun impact runtime ni sur le paquet publié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)