### PR TITLE
feat: Add checkPermission utility to query current permission state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Le pre-commit hook exécute automatiquement `typecheck` + `test:ci` + `lint` + `
 
 ## Architecture
 
-Bibliothèque utilitaire légère (~4 fonctions) écrite en **TypeScript**, qui encapsule les APIs navigateur `navigator.permissions` et `navigator.mediaDevices`. Les types des APIs navigateur (`PermissionName`, `PermissionState`, `MediaStreamConstraints`, `AbortSignal`) proviennent de la lib `DOM` de TypeScript.
+Bibliothèque utilitaire légère (~5 fonctions) écrite en **TypeScript**, qui encapsule les APIs navigateur `navigator.permissions` et `navigator.mediaDevices`. Les types des APIs navigateur (`PermissionName`, `PermissionState`, `MediaStreamConstraints`, `AbortSignal`) proviennent de la lib `DOM` de TypeScript.
 
 **Flux d'appel :**
 ```
@@ -32,10 +32,15 @@ getUserMediaStream
   └── getPermission
         └── isNavigatorPermissionsSupported (guard)
         └── navigator.permissions.query()
+
+checkPermission
+  └── isNavigatorPermissionsSupported  (guard)
+  └── navigator.permissions.query()
 ```
 
 - `isNavigatorPermissionsSupported` / `isNavigatorMediaDevicesSupported` : guards booléens sur l'existence des APIs navigateur.
 - `getPermission(permissionName)` : retourne une Promise qui se résout sur l'état de permission (`'granted'` / `'prompt'`) ou rejette avec `DOMException` si refusée ou non supportée. Écoute l'événement `change` pour détecter les changements d'état en temps réel.
+- `checkPermission(permissionName)` : retourne une Promise résolue immédiatement avec l'état courant de la permission (`'granted'` / `'denied'` / `'prompt'`), sans attendre d'interaction utilisateur ni rejeter sur `'denied'`. Passe par le même guard `isNavigatorPermissionsSupported` que `getPermission`. Utile pour lire l'état en amont (bannière, bouton désactivé, branchement UI).
 - `getUserMediaStream(permissionName, mediaStreamConstraints)` : combine `getPermission` + `navigator.mediaDevices.getUserMedia` via `Promise.all`.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ const init = async () => {
 controller.abort()
 ```
 
+`checkPermission`:
+
+Returns a promise resolved with the current permission state (`'granted'`, `'denied'` or `'prompt'`) immediately. Unlike `getPermission`, it never waits for user interaction and never rejects on `'denied'`. It rejects when the Permissions API is unsupported, and otherwise propagates any error from `navigator.permissions.query()` (e.g. an unrecognized permission name). Useful to read the current state upfront (show a permission banner, disable a button, branch UI logic) without triggering a prompt.
+
+```javascript
+import { checkPermission } from '@untemps/user-permissions-utils'
+
+const init = async () => {
+    try {
+        const state = await checkPermission('microphone') // 'granted' | 'denied' | 'prompt'
+        if (state === 'granted') {
+            // permission already available — start straight away
+            ...
+        } else if (state === 'prompt') {
+            // show a button that calls getPermission/getUserMediaStream on click
+            ...
+        }
+    } catch (error) {
+        // Thrown when the Permissions API is unsupported or the query fails
+        console.error(error)
+    }
+}
+```
+
 `getUserMediaStream`:
 
 Returns a promise resolved when the permission is granted and the stream is retrieved. Accepts an optional `signal` to cancel the entire operation.

--- a/demo/index.html
+++ b/demo/index.html
@@ -246,9 +246,9 @@
 				</div>
 			</div>
 
-			<!-- getPermission -->
+			<!-- checkPermission -->
 			<div class="card">
-				<div class="card-header">getPermission</div>
+				<div class="card-header">checkPermission</div>
 				<div class="card-body">
 					<div class="support-row">
 						<div class="dot" id="dot-permission-microphone"></div>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,11 +1,16 @@
-import { isNavigatorPermissionsSupported, isNavigatorMediaDevicesSupported, getUserMediaStream } from '../src/index'
+import {
+	isNavigatorPermissionsSupported,
+	isNavigatorMediaDevicesSupported,
+	getUserMediaStream,
+	checkPermission,
+} from '../src/index'
 
 let activeController: AbortController | null = null
 let activeStream: MediaStream | null = null
 
 const WATCHED_PERMISSIONS: PermissionName[] = ['microphone', 'camera']
 const STATE_DOT_CLASS: Record<string, string> = { granted: 'supported', denied: 'unsupported', prompt: 'prompt' }
-const STATE_LOG_TYPE: Record<string, string> = { granted: 'success', denied: 'error', prompt: '' }
+const STATE_LOG_TYPE: Record<string, string> = { granted: 'success', denied: 'warning', prompt: '' }
 const logEl = document.getElementById('log')!
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -37,8 +42,13 @@ function setSupport(key: string, ok: boolean): void {
 function initPermissionStates(permissionNames: PermissionName[]): void {
 	permissionNames.forEach(async (name) => {
 		try {
+			// Read the current state upfront through the library guard — no prompt, no waiting
+			const state = await checkPermission(name)
+			renderPermissionState(name, state)
+			log(`checkPermission("${name}") → ${state}`, STATE_LOG_TYPE[state])
+
+			// Subscribe to live changes (a capability checkPermission intentionally does not cover)
 			const status = await navigator.permissions.query({ name })
-			renderPermissionState(name, status.state)
 			status.addEventListener('change', () => {
 				renderPermissionState(name, status.state)
 				log(`permission "${name}" changed → ${status.state}`, STATE_LOG_TYPE[status.state])
@@ -46,7 +56,7 @@ function initPermissionStates(permissionNames: PermissionName[]): void {
 		} catch (err) {
 			const error = err as DOMException
 			renderPermissionState(name, 'error')
-			log(`getPermission("${name}") ✗ ${error.name}: ${error.message}`, 'error')
+			log(`checkPermission("${name}") ✗ ${error.name}: ${error.message}`, 'error')
 		}
 	})
 }

--- a/src/__tests__/checkPermission.test.ts
+++ b/src/__tests__/checkPermission.test.ts
@@ -1,0 +1,61 @@
+import checkPermission from '../checkPermission'
+import { setupPermissionsMock, teardownPermissionsMock, type MockPermissionStatus } from './testUtils'
+
+describe('checkPermission', () => {
+	describe('navigator.permissions is not implemented', () => {
+		beforeAll(() => {
+			;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
+		})
+
+		it('rejects promise', async () => {
+			await expect(checkPermission('microphone')).rejects.toMatchObject({
+				message: 'Navigator API: permissions not supported',
+				name: 'NOT_SUPPORTED_ERR',
+			})
+		})
+	})
+
+	describe('navigator.permissions is implemented', () => {
+		const mockPermissionsQuery = vi.fn()
+
+		beforeAll(() => setupPermissionsMock(mockPermissionsQuery))
+		beforeEach(() => mockPermissionsQuery.mockReset())
+		afterAll(teardownPermissionsMock)
+
+		it('resolves with "granted" state', async () => {
+			const status = new PermissionStatus() as unknown as MockPermissionStatus
+			status.state = 'granted'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			await expect(checkPermission('microphone')).resolves.toBe('granted')
+		})
+
+		it('resolves with "denied" state without rejecting', async () => {
+			const status = new PermissionStatus() as unknown as MockPermissionStatus
+			status.state = 'denied'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			await expect(checkPermission('microphone')).resolves.toBe('denied')
+		})
+
+		it('resolves with "prompt" state without waiting', async () => {
+			const status = new PermissionStatus() as unknown as MockPermissionStatus
+			status.state = 'prompt'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			await expect(checkPermission('microphone')).resolves.toBe('prompt')
+		})
+
+		it('queries the requested permission name', async () => {
+			const status = new PermissionStatus() as unknown as MockPermissionStatus
+			status.state = 'granted'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+			await checkPermission('camera')
+			expect(mockPermissionsQuery).toHaveBeenCalledWith({ name: 'camera' })
+		})
+
+		it('throws error', async () => {
+			mockPermissionsQuery.mockImplementationOnce(() => {
+				throw new Error('ERR')
+			})
+			await expect(checkPermission('microphone')).rejects.toEqual(new Error('ERR'))
+		})
+	})
+})

--- a/src/checkPermission.ts
+++ b/src/checkPermission.ts
@@ -1,0 +1,18 @@
+import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
+
+/**
+ * Returns a promise resolved with the current permission state without waiting for user interaction
+ * Unlike getPermission, it never waits on 'prompt' nor rejects on 'denied' — it resolves with the raw state
+ * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
+ */
+const checkPermission = async (permissionName: PermissionName): Promise<PermissionState> => {
+	if (!isNavigatorPermissionsSupported()) {
+		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+	}
+
+	const { state } = await navigator.permissions.query({ name: permissionName })
+
+	return state
+}
+
+export default checkPermission

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { default as isNavigatorPermissionsSupported } from './isNavigatorPermissionsSupported'
 export { default as isNavigatorMediaDevicesSupported } from './isNavigatorMediaDevicesSupported'
 export { default as getPermission } from './getPermission'
+export { default as checkPermission } from './checkPermission'
 export { default as getUserMediaStream } from './getUserMediaStream'
 export type { GetPermissionOptions } from './getPermission'
 export type { GetUserMediaStreamOptions } from './getUserMediaStream'


### PR DESCRIPTION
## Summary
Adds a `checkPermission(permissionName)` utility that resolves with the current permission state (`'granted' | 'denied' | 'prompt'`) **immediately**, without waiting for user interaction. It complements `getPermission` (which waits on `'prompt'` and rejects on `'denied'`) for UI patterns that need to read the current state upfront — e.g. show a permission banner, disable a button, or branch UI logic — without triggering a prompt or bypassing the library's guard logic.

## Changes
- `src/checkPermission.ts` — new utility. Goes through the `isNavigatorPermissionsSupported` guard (throws `DOMException` `NOT_SUPPORTED_ERR` when unsupported), then returns `(await navigator.permissions.query({ name })).state`. Typed `(permissionName: PermissionName) => Promise<PermissionState>`.
- `src/index.ts` — export `checkPermission`.
- `src/__tests__/checkPermission.test.ts` — 6 tests covering unsupported API, each resolved state (`granted`/`denied`/`prompt`), argument forwarding, and error propagation. Global 100% coverage maintained (38 tests total).
- `demo/` — read the initial permission state through `checkPermission` instead of calling `navigator.permissions.query()` directly (the raw query is kept only to subscribe to live `change` events, which `checkPermission` intentionally does not cover); `denied` now logs as a warning rather than an error.
- `README.md` / `CLAUDE.md` — document the new utility.

## Behaviour
- Resolves with the raw state for `granted`, `denied`, and `prompt` — never waits, never rejects on `denied`.
- Rejects only when the Permissions API is unsupported, and otherwise propagates any error from `navigator.permissions.query()` (e.g. an unrecognized permission name).

## Test plan
- [ ] `yarn test:ci` — 38 tests pass, 100% coverage
- [ ] `yarn typecheck` — no type errors
- [ ] `yarn build` — CJS/ES/UMD + `.d.ts` all export `checkPermission`
- [ ] `yarn lint` && prettier — clean
- [ ] `yarn dev` — demo boots; permission states render via `checkPermission`

## Breaking changes
None — purely additive export.

Closes #114