### PR TITLE
fix!: Prevent getPermission from hanging on 'prompt' state and leaking a listener

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,13 @@ Bibliothèque utilitaire légère (~5 fonctions) écrite en **TypeScript**, qui 
 getUserMediaStream
   └── isNavigatorPermissionsSupported  (guard)
   └── isNavigatorMediaDevicesSupported (guard)
-  └── getPermission
-        └── isNavigatorPermissionsSupported (guard)
-        └── navigator.permissions.query()
+  └── navigator.permissions.query()         (rejette si 'denied')
+  └── navigator.mediaDevices.getUserMedia() (Promise.race avec l'AbortSignal)
+
+getPermission
+  └── isNavigatorPermissionsSupported  (guard)
+  └── navigator.permissions.query()
+  └── (sur 'prompt') attend l'événement 'change', borné par signal/timeout
 
 checkPermission
   └── isNavigatorPermissionsSupported  (guard)
@@ -39,9 +43,9 @@ checkPermission
 ```
 
 - `isNavigatorPermissionsSupported` / `isNavigatorMediaDevicesSupported` : guards booléens sur l'existence des APIs navigateur.
-- `getPermission(permissionName)` : retourne une Promise qui se résout sur l'état de permission (`'granted'` / `'prompt'`) ou rejette avec `DOMException` si refusée ou non supportée. Écoute l'événement `change` pour détecter les changements d'état en temps réel.
+- `getPermission(permissionName, { signal?, timeout? })` : watcher **passif** qui résout sur `'granted'` une fois la permission accordée. `navigator.permissions.query()` n'affiche **jamais** de dialogue : `'granted'` résout immédiatement, `'denied'` rejette (`NOT_ALLOWED_ERR`). Sur `'prompt'`, attend l'événement `change` (déclenché seulement quand autre chose provoque la vraie requête, ex. `getUserMediaStream`) ; comme rien ne fait transitionner l'état tout seul, l'attente doit être **bornée** par `timeout` (rejette `TimeoutError`) et/ou `signal`. Sans aucune des deux sur `'prompt'`, rejette immédiatement (`InvalidStateError`) au lieu de rester pendante à jamais. Le listener `change` est nettoyé sur tous les chemins de résolution.
 - `checkPermission(permissionName)` : retourne une Promise résolue immédiatement avec l'état courant de la permission (`'granted'` / `'denied'` / `'prompt'`), sans attendre d'interaction utilisateur ni rejeter sur `'denied'`. Passe par le même guard `isNavigatorPermissionsSupported` que `getPermission`. Utile pour lire l'état en amont (bannière, bouton désactivé, branchement UI).
-- `getUserMediaStream(permissionName, mediaStreamConstraints)` : combine `getPermission` + `navigator.mediaDevices.getUserMedia` via `Promise.all`.
+- `getUserMediaStream(permissionName, mediaStreamConstraints, { signal? })` : appelle directement `navigator.permissions.query()` (rejette si `'denied'`) puis `navigator.mediaDevices.getUserMedia()` — c'est `getUserMedia` qui déclenche le vrai dialogue. N'appelle **pas** `getPermission` et n'est donc pas concerné par le contrat d'attente bornée ; l'`AbortSignal` est géré via `Promise.race`.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,19 @@ import { getPermission, getUserMediaStream, type GetPermissionOptions, type GetU
 
 `getPermission`:
 
-Returns a promise resolved when the permission is granted. Accepts an optional `signal` to cancel the pending wait.
+Watches a permission and resolves with `'granted'` once it is granted. It is a **passive** watcher built on `navigator.permissions.query()`, so **it never displays a permission dialog**: an already-`'granted'` state resolves right away, while a `'denied'` state rejects with a `NOT_ALLOWED_ERR` `DOMException`.
+
+When the state is `'prompt'`, `getPermission` waits for the `change` event — which only fires once _something else_ triggers the real request (e.g. `getUserMediaStream`, `geolocation.getCurrentPosition`) and the user responds. Since nothing transitions a `'prompt'` state on its own, **the wait must be bounded**: pass a `timeout` (rejects with a `TimeoutError` once elapsed), a `signal`, or both. If you provide neither while the state is `'prompt'`, the promise rejects immediately with an `InvalidStateError` instead of hanging forever.
+
+To actually surface a permission dialog, use `getUserMediaStream` (which calls `navigator.mediaDevices.getUserMedia()`) or trigger the relevant browser API yourself — `getPermission` only observes the state.
 
 ```javascript
 import { getPermission } from '@untemps/user-permissions-utils'
 
 const init = async () => {
     try {
-    	await getPermission('microphone')
+        // Resolves immediately if already granted, otherwise waits up to 5s
+        await getPermission('microphone', { timeout: 5000 })
         ...
     } catch (error) {
         console.error(error)
@@ -58,7 +63,7 @@ const init = async () => {
     }
 }
 
-// Cancel before the user responds to the permission dialog
+// Cancel while still waiting for the permission to be granted
 controller.abort()
 ```
 

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -52,7 +52,7 @@ describe('getPermission', () => {
 				listener({ target: { state: 'denied' } })
 			})
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			await expect(getPermission('microphone')).rejects.toMatchObject({
+			await expect(getPermission('microphone', { timeout: 1000 })).rejects.toMatchObject({
 				message: 'Permission denied',
 				name: 'NOT_ALLOWED_ERR',
 			})
@@ -65,7 +65,7 @@ describe('getPermission', () => {
 				listener({ target: { state: 'granted' } })
 			})
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			await expect(getPermission('microphone')).resolves.toBe('granted')
+			await expect(getPermission('microphone', { timeout: 1000 })).resolves.toBe('granted')
 		})
 
 		it('throws error', async () => {
@@ -73,6 +73,64 @@ describe('getPermission', () => {
 				throw new Error('ERR')
 			})
 			await expect(getPermission('microphone')).rejects.toEqual(new Error('ERR'))
+		})
+
+		describe('bounded wait (prompt state)', () => {
+			it('rejects immediately when state is prompt and neither signal nor timeout is provided', async () => {
+				const status = new PermissionStatus() as unknown as MockPermissionStatus
+				status.state = 'prompt'
+				status.addEventListener = vi.fn()
+				status.removeEventListener = vi.fn()
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				await expect(getPermission('microphone')).rejects.toMatchObject({
+					name: 'InvalidStateError',
+				})
+				// It must not start watching when it cannot ever settle
+				expect(status.addEventListener).not.toHaveBeenCalled()
+			})
+
+			it('rejects with TimeoutError when timeout elapses before the permission changes', async () => {
+				vi.useFakeTimers()
+				try {
+					const status = new PermissionStatus() as unknown as MockPermissionStatus
+					status.state = 'prompt'
+					status.addEventListener = vi.fn()
+					status.removeEventListener = vi.fn()
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+
+					const promise = getPermission('microphone', { timeout: 1000 })
+					const expectation = expect(promise).rejects.toMatchObject({ name: 'TimeoutError' })
+					await vi.advanceTimersByTimeAsync(1000)
+					await expectation
+
+					// The change listener must be removed on timeout (no leak)
+					expect(status.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+				} finally {
+					vi.useRealTimers()
+				}
+			})
+
+			it('clears the timeout when the permission is granted before it elapses', async () => {
+				vi.useFakeTimers()
+				try {
+					const status = new PermissionStatus() as unknown as MockPermissionStatus
+					status.state = 'prompt'
+					status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
+						listener({ target: { state: 'granted' } })
+					})
+					status.removeEventListener = vi.fn()
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+
+					const promise = getPermission('microphone', { timeout: 1000 })
+					await expect(promise).resolves.toBe('granted')
+
+					// The scheduled timeout must have been cleared — no leaked timer left pending
+					expect(vi.getTimerCount()).toBe(0)
+				} finally {
+					vi.useRealTimers()
+				}
+			})
 		})
 
 		describe('AbortSignal', () => {
@@ -158,6 +216,21 @@ describe('getPermission', () => {
 				status.addEventListener = vi.fn()
 				status.removeEventListener = vi.fn()
 				// Abort synchronously inside the mock so signal is aborted when await resolves
+				mockPermissionsQuery.mockImplementationOnce(() => {
+					controller.abort()
+					return Promise.resolve(status)
+				})
+
+				await expect(getPermission('microphone', { signal: controller.signal })).rejects.toMatchObject({
+					name: 'AbortError',
+				})
+			})
+
+			it('rejects when aborted during query resolution even if the state resolves to granted', async () => {
+				const controller = new AbortController()
+				const status = new PermissionStatus() as unknown as MockPermissionStatus
+				status.state = 'granted'
+				// Abort synchronously inside the mock so the signal is aborted once the query settles
 				mockPermissionsQuery.mockImplementationOnce(() => {
 					controller.abort()
 					return Promise.resolve(status)

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -131,6 +131,38 @@ describe('getPermission', () => {
 					vi.useRealTimers()
 				}
 			})
+
+			it('keeps waiting when a change event leaves the state in prompt and only settles on a terminal state', async () => {
+				vi.useFakeTimers()
+				try {
+					let changeListener!: StatusChangeListener
+					const status = new PermissionStatus() as unknown as MockPermissionStatus
+					status.state = 'prompt'
+					status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
+						changeListener = listener
+					})
+					status.removeEventListener = vi.fn()
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+
+					const promise = getPermission('microphone', { timeout: 1000 })
+					await flushMicrotasks()
+
+					// A `change` event that leaves the state in `'prompt'` must not settle the
+					// promise (`Promise<'granted'>` must never resolve with `'prompt'`) and must
+					// not tear down the still-bounded watch.
+					changeListener({ target: { state: 'prompt' } })
+					expect(status.removeEventListener).not.toHaveBeenCalled()
+					expect(vi.getTimerCount()).toBe(1)
+
+					// A later transition to a terminal state settles it and cleans everything up.
+					changeListener({ target: { state: 'granted' } })
+					await expect(promise).resolves.toBe('granted')
+					expect(status.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+					expect(vi.getTimerCount()).toBe(0)
+				} finally {
+					vi.useRealTimers()
+				}
+			})
 		})
 
 		describe('AbortSignal', () => {

--- a/src/getPermission.ts
+++ b/src/getPermission.ts
@@ -61,9 +61,16 @@ const getPermission = async (
 			}
 
 			const onChange = (event: Event) => {
+				const state = (event.target as PermissionStatus).state
+				// A `change` event only settles the wait on a terminal state. Ignore any event
+				// that leaves us in `'prompt'` so the watcher keeps waiting (still bounded by
+				// `signal`/`timeout`) instead of settling with a non-`'granted'` value.
+				if (state === 'prompt') {
+					return
+				}
 				cleanup()
 				try {
-					resolve(resolveOrRejectBasedOnState((event.target as PermissionStatus).state))
+					resolve(resolveOrRejectBasedOnState(state))
 				} catch (error) {
 					reject(error)
 				}
@@ -89,11 +96,14 @@ const getPermission = async (
 	return resolveOrRejectBasedOnState(permissionStatus.state)
 }
 
-const resolveOrRejectBasedOnState = (state: PermissionState): 'granted' => {
+// Accepts only terminal states: `'prompt'` is excluded at the type level, so every caller must
+// filter it out first. After the `'denied'` throw, TypeScript narrows `state` to `'granted'`, so
+// the return needs no cast — the `Promise<'granted'>` contract is enforced by the compiler.
+const resolveOrRejectBasedOnState = (state: Exclude<PermissionState, 'prompt'>): 'granted' => {
 	if (state === 'denied') {
 		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
 	}
-	return state as 'granted'
+	return state
 }
 
 export default getPermission

--- a/src/getPermission.ts
+++ b/src/getPermission.ts
@@ -2,17 +2,34 @@ import isNavigatorPermissionsSupported from './isNavigatorPermissionsSupported'
 
 export interface GetPermissionOptions {
 	signal?: AbortSignal
+	timeout?: number
 }
 
 /**
- * Returns a promise resolved when the permission is granted by the user
+ * Watches the current state of a permission and resolves once it is `'granted'`.
+ *
+ * This is a **passive** watcher: it reads the state through `navigator.permissions.query()`,
+ * which never displays a permission dialog. When the state is `'prompt'`, it waits for the
+ * `change` event — which only fires when something else (e.g. `getUserMediaStream`,
+ * `geolocation.getCurrentPosition`) triggers the real request and the user responds.
+ *
+ * Because nothing transitions a `'prompt'` state on its own, the wait must be bounded: pass a
+ * `signal`, a `timeout`, or both. If neither is provided while the state is `'prompt'`, the
+ * promise rejects immediately with an `InvalidStateError` instead of hanging forever.
+ *
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
  * @param options                   Optional settings
- * @param options.signal            Optional AbortSignal to cancel the pending permission wait
+ * @param options.signal            Optional AbortSignal to cancel the pending wait (rejects with the signal reason)
+ * @param options.timeout           Optional timeout in milliseconds; rejects with a `TimeoutError` once elapsed
+ * @returns A promise resolved with `'granted'`
+ * @throws {DOMException} `NOT_SUPPORTED_ERR` when the Permissions API is unavailable
+ * @throws {DOMException} `NOT_ALLOWED_ERR` when the permission is (or becomes) `'denied'`
+ * @throws {DOMException} `InvalidStateError` when the state is `'prompt'` and neither `signal` nor `timeout` is provided
+ * @throws {DOMException} `TimeoutError` when `timeout` elapses before the permission is granted
  */
 const getPermission = async (
 	permissionName: PermissionName,
-	{ signal }: GetPermissionOptions = {}
+	{ signal, timeout }: GetPermissionOptions = {}
 ): Promise<'granted'> => {
 	if (!isNavigatorPermissionsSupported()) {
 		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
@@ -22,13 +39,29 @@ const getPermission = async (
 
 	const permissionStatus = await navigator.permissions.query({ name: permissionName })
 
-	if (permissionStatus.state === 'prompt') {
-		return new Promise<'granted'>((resolve, reject) => {
-			signal?.throwIfAborted()
+	signal?.throwIfAborted()
 
-			const onChange = (event: Event) => {
+	if (permissionStatus.state === 'prompt') {
+		if (!signal && timeout === undefined) {
+			throw new DOMException(
+				'Permission is in "prompt" state and would never settle: navigator.permissions does not display a dialog. Provide a `signal` and/or `timeout` to bound the wait, or trigger the prompt (e.g. via getUserMediaStream).',
+				'InvalidStateError'
+			)
+		}
+
+		return new Promise<'granted'>((resolve, reject) => {
+			let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+			const cleanup = () => {
 				permissionStatus.removeEventListener('change', onChange)
 				signal?.removeEventListener('abort', onAbort)
+				if (timeoutId !== undefined) {
+					clearTimeout(timeoutId)
+				}
+			}
+
+			const onChange = (event: Event) => {
+				cleanup()
 				try {
 					resolve(resolveOrRejectBasedOnState((event.target as PermissionStatus).state))
 				} catch (error) {
@@ -37,8 +70,15 @@ const getPermission = async (
 			}
 
 			const onAbort = () => {
-				permissionStatus.removeEventListener('change', onChange)
+				cleanup()
 				reject(signal!.reason)
+			}
+
+			if (timeout !== undefined) {
+				timeoutId = setTimeout(() => {
+					cleanup()
+					reject(new DOMException(`Permission request timed out after ${timeout}ms`, 'TimeoutError'))
+				}, timeout)
 			}
 
 			permissionStatus.addEventListener('change', onChange)


### PR DESCRIPTION
## Summary
`getPermission()` never settled when a permission was in its default `'prompt'` state, and it leaked the `change` listener for the lifetime of the page. `navigator.permissions.query()` is a **passive** read — it never shows a dialog — so on `'prompt'` the promise only resolved on a `change` event that nothing triggers standalone, hanging forever (the documented README happy path). 100% coverage masked this because the tests mocked `addEventListener` to fire `change` synchronously.

This implements contract **(a)** from the issue: keep `getPermission` a passive watcher, but make the wait impossible to hang and impossible to leak.

## Changes
- Add an optional `timeout?: number` to `GetPermissionOptions` → rejects with a `TimeoutError` once elapsed.
- On a `'prompt'` state with **neither** `signal` **nor** `timeout`, reject immediately with an `InvalidStateError` instead of hanging forever.
- Centralise listener/timer teardown in a single `cleanup()` so the `change` listener (and any pending timer) is removed on **every** settle path — fixing the leak.
- Honour an `AbortSignal` that fires while the permissions query is in flight for every resolved state (not just `'prompt'`), matching `getUserMediaStream`.
- **Settle only on terminal states.** The `change` handler now ignores any event that leaves the state in `'prompt'` (it keeps waiting, still bounded by `signal`/`timeout`) instead of resolving the `Promise<'granted'>` with the non-`'granted'` value `'prompt'` and tearing down the watch. `resolveOrRejectBasedOnState` is narrowed to `Exclude<PermissionState, 'prompt'>`, which removes the unsound `as 'granted'` cast and makes passing a possibly-`'prompt'` value a **compile error** at both call sites — so the guard can't be silently dropped in a future refactor (defense in depth).
- Rewrite the JSDoc, README and CLAUDE.md so they no longer imply a dialog is shown, document `timeout`, and describe the bounded-wait contract. Also corrects a stale CLAUDE.md claim that `getUserMediaStream` delegates to `getPermission`.

## ⚠️ Breaking changes
- **`getPermission` on a `'prompt'` state**: previously returned a promise that never settled when called without a bound; it now **rejects immediately with `InvalidStateError`** unless a `signal` and/or `timeout` is provided.
- **`getPermission` with an already-aborted (or aborted-during-query) `signal`**: the abort is now honoured on **every** resolved state, not just `'prompt'`. Previously `throwIfAborted` was only checked inside the `'prompt'` wait, so a synchronously-`'granted'` query resolved with `'granted'` even though the signal was already aborted; it now **rejects with the signal's reason** (e.g. `AbortError`) on the `'granted'`/`'denied'` paths too. This aligns `getPermission` with `getUserMediaStream`. Callers that abort only *after* the permission has settled are unaffected.
- Migration: pass `getPermission(name, { timeout })` and/or `{ signal }` to bound the wait, or trigger the real prompt via `getUserMediaStream`. Callers that already pass `{ signal }` are unaffected; the return type is still `Promise<'granted'>`.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:ci` — 43 tests pass, **100% coverage** maintained (statements/branches/functions/lines)
- [x] New regression test proves a no-bound `'prompt'` call rejects (no longer hangs)
- [x] New tests for the `TimeoutError` path, the `clearTimeout`-on-grant path (asserted falsifiably via `vi.getTimerCount()`), and an abort landing during the query for a `'granted'` state
- [x] New regression test proves a `change` event leaving the state in `'prompt'` neither settles the promise nor tears down the bounded watch, while a later `'granted'` transition resolves (falsifiability verified: reverting the guard fails exactly this test; removing it fails `tsc`)
- [x] `yarn build`
- [x] `yarn lint`
- [x] `prettier --check`
- [x] Demo still builds clean (it uses `getUserMediaStream` + `checkPermission`, not `getPermission`)

Closes #123

