### PR TITLE
docs: Reflect signal-only Promise.race flow in CLAUDE.md (#126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ getUserMediaStream
   └── isNavigatorPermissionsSupported  (guard)
   └── isNavigatorMediaDevicesSupported (guard)
   └── navigator.permissions.query()         (rejette si 'denied')
-  └── navigator.mediaDevices.getUserMedia() (Promise.race avec l'AbortSignal)
+  └── navigator.mediaDevices.getUserMedia() (Promise.race avec le signal, uniquement si fourni)
 
 getPermission
   └── isNavigatorPermissionsSupported  (guard)
@@ -45,7 +45,7 @@ checkPermission
 - `isNavigatorPermissionsSupported` / `isNavigatorMediaDevicesSupported` : guards booléens sur l'existence des APIs navigateur.
 - `getPermission(permissionName, { signal?, timeout? })` : watcher **passif** qui résout sur `'granted'` une fois la permission accordée. `navigator.permissions.query()` n'affiche **jamais** de dialogue : `'granted'` résout immédiatement, `'denied'` rejette (`NOT_ALLOWED_ERR`). Sur `'prompt'`, attend l'événement `change` (déclenché seulement quand autre chose provoque la vraie requête, ex. `getUserMediaStream`) ; comme rien ne fait transitionner l'état tout seul, l'attente doit être **bornée** par `timeout` (rejette `TimeoutError`) et/ou `signal`. Sans aucune des deux sur `'prompt'`, rejette immédiatement (`InvalidStateError`) au lieu de rester pendante à jamais. Le listener `change` est nettoyé sur tous les chemins de résolution.
 - `checkPermission(permissionName)` : retourne une Promise résolue immédiatement avec l'état courant de la permission (`'granted'` / `'denied'` / `'prompt'`), sans attendre d'interaction utilisateur ni rejeter sur `'denied'`. Passe par le même guard `isNavigatorPermissionsSupported` que `getPermission`. Utile pour lire l'état en amont (bannière, bouton désactivé, branchement UI).
-- `getUserMediaStream(permissionName, mediaStreamConstraints, { signal? })` : appelle directement `navigator.permissions.query()` (rejette si `'denied'`) puis `navigator.mediaDevices.getUserMedia()` — c'est `getUserMedia` qui déclenche le vrai dialogue. N'appelle **pas** `getPermission` et n'est donc pas concerné par le contrat d'attente bornée ; l'`AbortSignal` est géré via `Promise.race`.
+- `getUserMediaStream(permissionName, mediaStreamConstraints, { signal? })` : appelle directement `navigator.permissions.query()` (rejette si `'denied'`) puis `navigator.mediaDevices.getUserMedia()` — c'est `getUserMedia` qui déclenche le vrai dialogue. N'appelle **pas** `getPermission` et n'est donc pas concerné par le contrat d'attente bornée ; l'`AbortSignal` n'est géré via `Promise.race` que lorsqu'un `signal` est fourni, sinon la promesse de `getUserMedia` est renvoyée directement.
 
 ## Build
 


### PR DESCRIPTION
## Summary
Issue #126 reported four factual errors in `CLAUDE.md` (call flow / `Promise.all`, `getPermission` resolution, sourcemaps, missing `{ signal }` signatures). Three-and-a-half of those were **already fixed on `beta`** by #135, which rewrote the Architecture section when it landed the bounded-wait `getPermission`. This PR closes the **one remaining in-scope gap**: the docs still presented `Promise.race` as `getUserMediaStream`'s unconditional abort mechanism.

In reality (`src/getUserMediaStream.ts:38`), `getUserMediaStream` returns the bare `getUserMedia()` promise directly when no signal is passed, and only wraps it in `Promise.race` **when a `signal` is provided** — exactly the "Promise.race (signal-only)" flow #126 asked the docs to reflect.

## Changes
- **Flux d'appel diagram**: `getUserMedia() (Promise.race avec l'AbortSignal)` → `(Promise.race avec le signal, uniquement si fourni)`.
- **`getUserMediaStream` bullet**: clarified that `Promise.race` is used only when a `signal` is provided, otherwise the `getUserMedia` promise is returned directly.

## Context — full accuracy audit
Rather than trust the issue text (filed against a pre-#135, pre-TypeScript state), every claim in `CLAUDE.md` was re-verified against the current code/config. Result across **32 claims: 0 inaccurate, 1 imprecise, 31 accurate**. The single imprecise claim is the one this PR fixes; #126's other three points are confirmed already-correct on `beta`.

## Test plan
- [x] `yarn typecheck` — passes
- [x] `yarn lint` — passes
- [x] `yarn test:ci` — 43 tests pass, 100% coverage
- [x] Docs-only change; no runtime/API impact

Closes #126