### PR TITLE
chore: Validate pull requests with a reusable CI check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,40 @@
+name: 'Check'
+on:
+    pull_request:
+        branches:
+            - main
+            - beta
+    workflow_call:
+permissions:
+    contents: read
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+                  cache: 'yarn'
+            - run: yarn install --frozen-lockfile
+            - run: yarn typecheck
+            - run: yarn test:ci
+            - run: yarn lint
+            - run: yarn build
+            # On the workflow_call path the github context is the caller's, so
+            # event_name is 'push' when invoked by publish.yml — that is what lets
+            # the publish job reuse this dist instead of rebuilding.
+            - uses: actions/upload-artifact@v4
+              if: success() && github.event_name == 'push'
+              with:
+                  name: dist
+                  path: dist
+                  retention-days: 1
+            - uses: codecov/codecov-action@v6
+              if: ${{ !cancelled() }}
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: coverage/lcov.info

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: 'CodeQL'
+on:
+    push:
+        branches:
+            - main
+            - beta
+    pull_request:
+        branches:
+            - main
+            - beta
+    schedule:
+        - cron: '28 12 * * 3'
+jobs:
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ['javascript']
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: ${{ matrix.language }}
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: '/language:${{matrix.language}}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,11 @@ permissions:
     pull-requests: write
     issues: write
 jobs:
+    check:
+        uses: ./.github/workflows/check.yml
+        secrets: inherit
     publish:
+        needs: check
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -21,14 +25,10 @@ jobs:
                   node-version: '24'
                   cache: 'yarn'
             - run: yarn install --frozen-lockfile
-            - run: yarn typecheck
-            - run: yarn test:ci
-            - run: yarn lint
-            - run: yarn build
+            - uses: actions/download-artifact@v4
+              with:
+                  name: dist
+                  path: dist
             - run: npx semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-            - uses: codecov/codecov-action@v5
-              with:
-                  token: ${{ secrets.CODECOV_TOKEN }}
-                  files: coverage/lcov.info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,14 @@ Vite (lib mode) compile `src/index.ts` en 3 formats via `vite.config.js` :
 
 Les déclarations de types (`dist/index.d.ts` et fichiers associés) sont générées automatiquement par `vite-plugin-dts` à partir des sources TypeScript — il n'y a plus de `src/index.d.ts` maintenu à la main. Vite nettoie `dist/` automatiquement avant chaque build. Sourcemaps désactivés (`sourcemap: false`).
 
+## CI
+
+Trois workflows GitHub Actions dans `.github/workflows/` :
+
+- `check.yml` : workflow **réutilisable** déclenché sur `pull_request` (vers `main` et `beta`) et via `workflow_call`. Installe les dépendances puis enchaîne `typecheck` + `test:ci` + `lint` + `build`, upload la couverture sur Codecov, et publie `dist/` en artifact **uniquement sur push** (pour que `publish.yml` le réutilise). C'est la validation pré-merge des PR.
+- `publish.yml` : sur push `main`/`beta`, appelle d'abord `check.yml` (`secrets: inherit` pour transmettre `CODECOV_TOKEN`), puis le job `publish` (`needs: check`) télécharge l'artifact `dist` au lieu de rebuilder et lance `npx semantic-release`. La publication reste donc protégée par la validation complète.
+- `codeql.yml` : analyse de sécurité CodeQL (JavaScript/TypeScript) sur push, PR et un cron hebdomadaire.
+
 ## Release
 
 Semantic-release gère versioning + changelog + publish npm automatiquement depuis la CI sur push `main` (canal stable) et `beta` (canal pré-release : ex. `2.0.0-beta.1` publié sous le tag npm `beta`). Les commits de type `chore` déclenchent un patch release (règle custom dans `package.json`).


### PR DESCRIPTION
## Summary
There was no pre-merge validation: the only workflow ran on push and immediately published, so pull requests got zero test/lint/build feedback (issue #127). This adopts the CI strategy used by [`untemps/utils`](https://github.com/untemps/utils): a reusable `check` workflow that validates PRs **and** is reused by the release flow, plus CodeQL security analysis.

## Changes
- **`.github/workflows/check.yml`** (new) — reusable workflow on `pull_request` (→ `main`, `beta`) **and** `workflow_call`. Runs `yarn install` → `typecheck` → `test:ci` → `lint` → `build`, uploads coverage to Codecov, and uploads `dist/` as an artifact **only on push** so the release job can reuse it. `permissions: contents: read` + a `concurrency` group that cancels superseded runs.
- **`.github/workflows/publish.yml`** (refactor) — now calls `check.yml` (`secrets: inherit`, to forward `CODECOV_TOKEN`), then the `publish` job (`needs: check`) **downloads the `dist` artifact instead of rebuilding** before `npx semantic-release`. Publishing stays gated by the full validation and is unchanged otherwise.
- **`.github/workflows/codeql.yml`** (new) — CodeQL analysis (JavaScript/TypeScript) on push, PR, and a weekly cron.
- **`CLAUDE.md`** — documents the three workflows.

## Notes on adapting the `utils` strategy
- `utils` folds lint into `test:ci`; ours is coverage-only, so `check.yml` keeps an explicit `yarn lint` step — preserving the validation set the old `publish.yml` ran inline.
- Codecov keeps the existing `CODECOV_TOKEN` (via `secrets: inherit`) rather than going fully tokenless, to avoid regressing coverage uploads.
- Action/Node versions match the existing `publish.yml` (`checkout@v6`, `setup-node@v6`, Node 24).

## Test plan
- [x] `yarn typecheck`, `yarn test:ci` (43 tests, 100% coverage), `yarn lint`, `yarn build` all green locally
- [x] All three workflow files parse as valid YAML
- [x] `dist/` artifact contents (`index.js`/`.es.js`/`.umd.js` + `.d.ts`) match the package's `files`/entry points, so `semantic-release` can publish from the downloaded artifact without rebuilding
- [ ] On merge: confirm `check` runs on this PR and `publish` reuses the artifact on the next push

## Follow-up (repo settings, cannot be done in this PR)
To actually *gate* merges, add a branch-protection rule / ruleset on `beta` (and `main`) requiring the **`check`** status check to pass — issue #127 lists this as optional, and it can only be configured in repo settings, not in YAML. The repo currently has no protection enabling this.

## Release impact
No code/API change. As a `chore`, merging cuts a patch prerelease (`2.0.0-beta.5`) per the repo's `chore→patch` rule.

Closes #127