### PR TITLE
test: Improve test hygiene for navigator mocks and permission watcher

### DIFF
--- a/src/__tests__/checkPermission.test.ts
+++ b/src/__tests__/checkPermission.test.ts
@@ -1,11 +1,16 @@
 import checkPermission from '../checkPermission'
-import { setupPermissionsMock, teardownPermissionsMock, type MockPermissionStatus } from './testUtils'
+import {
+	setNavigatorApiUnsupported,
+	restoreNavigatorApi,
+	setupPermissionsMock,
+	teardownPermissionsMock,
+	type MockPermissionStatus,
+} from './testUtils'
 
 describe('checkPermission', () => {
 	describe('navigator.permissions is not implemented', () => {
-		beforeAll(() => {
-			;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
-		})
+		beforeAll(() => setNavigatorApiUnsupported('permissions'))
+		afterAll(() => restoreNavigatorApi('permissions'))
 
 		it('rejects promise', async () => {
 			await expect(checkPermission('microphone')).rejects.toMatchObject({

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -6,7 +6,6 @@ import {
 	setupPermissionsMock,
 	teardownPermissionsMock,
 	type MockPermissionStatus,
-	type StatusChangeListener,
 } from './testUtils'
 
 describe('getPermission', () => {
@@ -49,24 +48,29 @@ describe('getPermission', () => {
 		it('rejects promise since user has been prompted and has denied permissions', async () => {
 			const status = new PermissionStatus() as unknown as MockPermissionStatus
 			status.state = 'prompt'
-			status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
-				listener({ target: { state: 'denied' } })
-			})
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			await expect(getPermission('microphone', { timeout: 1000 })).rejects.toMatchObject({
+
+			const promise = getPermission('microphone', { timeout: 1000 })
+			const expectation = expect(promise).rejects.toMatchObject({
 				message: 'Permission denied',
 				name: 'NOT_ALLOWED_ERR',
 			})
+			await flushMicrotasks()
+			status.state = 'denied'
+			status.dispatchEvent(new Event('change'))
+			await expectation
 		})
 
 		it('resolves promise since user has been prompted and has granted permissions', async () => {
 			const status = new PermissionStatus() as unknown as MockPermissionStatus
 			status.state = 'prompt'
-			status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
-				listener({ target: { state: 'granted' } })
-			})
 			mockPermissionsQuery.mockResolvedValueOnce(status)
-			await expect(getPermission('microphone', { timeout: 1000 })).resolves.toBe('granted')
+
+			const promise = getPermission('microphone', { timeout: 1000 })
+			await flushMicrotasks()
+			status.state = 'granted'
+			status.dispatchEvent(new Event('change'))
+			await expect(promise).resolves.toBe('granted')
 		})
 
 		it('throws error', async () => {
@@ -80,15 +84,14 @@ describe('getPermission', () => {
 			it('rejects immediately when state is prompt and neither signal nor timeout is provided', async () => {
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				status.addEventListener = vi.fn()
-				status.removeEventListener = vi.fn()
+				const addEventListenerSpy = vi.spyOn(status, 'addEventListener')
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				await expect(getPermission('microphone')).rejects.toMatchObject({
 					name: 'InvalidStateError',
 				})
 				// It must not start watching when it cannot ever settle
-				expect(status.addEventListener).not.toHaveBeenCalled()
+				expect(addEventListenerSpy).not.toHaveBeenCalled()
 			})
 
 			it('rejects with TimeoutError when timeout elapses before the permission changes', async () => {
@@ -96,8 +99,7 @@ describe('getPermission', () => {
 				try {
 					const status = new PermissionStatus() as unknown as MockPermissionStatus
 					status.state = 'prompt'
-					status.addEventListener = vi.fn()
-					status.removeEventListener = vi.fn()
+					const removeEventListenerSpy = vi.spyOn(status, 'removeEventListener')
 					mockPermissionsQuery.mockResolvedValueOnce(status)
 
 					const promise = getPermission('microphone', { timeout: 1000 })
@@ -106,7 +108,7 @@ describe('getPermission', () => {
 					await expectation
 
 					// The change listener must be removed on timeout (no leak)
-					expect(status.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+					expect(removeEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function))
 				} finally {
 					vi.useRealTimers()
 				}
@@ -117,13 +119,12 @@ describe('getPermission', () => {
 				try {
 					const status = new PermissionStatus() as unknown as MockPermissionStatus
 					status.state = 'prompt'
-					status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
-						listener({ target: { state: 'granted' } })
-					})
-					status.removeEventListener = vi.fn()
 					mockPermissionsQuery.mockResolvedValueOnce(status)
 
 					const promise = getPermission('microphone', { timeout: 1000 })
+					await flushMicrotasks()
+					status.state = 'granted'
+					status.dispatchEvent(new Event('change'))
 					await expect(promise).resolves.toBe('granted')
 
 					// The scheduled timeout must have been cleared — no leaked timer left pending
@@ -136,13 +137,9 @@ describe('getPermission', () => {
 			it('keeps waiting when a change event leaves the state in prompt and only settles on a terminal state', async () => {
 				vi.useFakeTimers()
 				try {
-					let changeListener!: StatusChangeListener
 					const status = new PermissionStatus() as unknown as MockPermissionStatus
 					status.state = 'prompt'
-					status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
-						changeListener = listener
-					})
-					status.removeEventListener = vi.fn()
+					const removeEventListenerSpy = vi.spyOn(status, 'removeEventListener')
 					mockPermissionsQuery.mockResolvedValueOnce(status)
 
 					const promise = getPermission('microphone', { timeout: 1000 })
@@ -151,14 +148,15 @@ describe('getPermission', () => {
 					// A `change` event that leaves the state in `'prompt'` must not settle the
 					// promise (`Promise<'granted'>` must never resolve with `'prompt'`) and must
 					// not tear down the still-bounded watch.
-					changeListener({ target: { state: 'prompt' } })
-					expect(status.removeEventListener).not.toHaveBeenCalled()
+					status.dispatchEvent(new Event('change'))
+					expect(removeEventListenerSpy).not.toHaveBeenCalled()
 					expect(vi.getTimerCount()).toBe(1)
 
 					// A later transition to a terminal state settles it and cleans everything up.
-					changeListener({ target: { state: 'granted' } })
+					status.state = 'granted'
+					status.dispatchEvent(new Event('change'))
 					await expect(promise).resolves.toBe('granted')
-					expect(status.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+					expect(removeEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function))
 					expect(vi.getTimerCount()).toBe(0)
 				} finally {
 					vi.useRealTimers()
@@ -187,8 +185,6 @@ describe('getPermission', () => {
 				const reason = new DOMException('Custom reason', 'AbortError')
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				status.addEventListener = vi.fn()
-				status.removeEventListener = vi.fn()
 				mockPermissionsQuery.mockImplementationOnce(() => {
 					controller.abort(reason)
 					return Promise.resolve(status)
@@ -201,8 +197,6 @@ describe('getPermission', () => {
 				const reason = new DOMException('Custom reason', 'AbortError')
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				status.addEventListener = vi.fn()
-				status.removeEventListener = vi.fn()
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				const promise = getPermission('microphone', { signal: controller.signal })
@@ -217,13 +211,16 @@ describe('getPermission', () => {
 				const removeAbortSpy = vi.spyOn(controller.signal, 'removeEventListener')
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				status.addEventListener = vi.fn((_event: string, listener: StatusChangeListener) => {
-					listener({ target: { state: 'granted' } })
-				})
-				status.removeEventListener = vi.fn()
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
-				await expect(getPermission('microphone', { signal: controller.signal })).resolves.toBe('granted')
+				const promise = getPermission('microphone', { signal: controller.signal })
+				await flushMicrotasks()
+				status.state = 'granted'
+				status.dispatchEvent(new Event('change'))
+
+				await expect(promise).resolves.toBe('granted')
+				// The abort listener was genuinely registered (the watch was pending) and is removed
+				// on cleanup — only the real async path exercises this ordering.
 				expect(removeAbortSpy).toHaveBeenCalledWith('abort', expect.any(Function))
 			})
 
@@ -231,8 +228,6 @@ describe('getPermission', () => {
 				const controller = new AbortController()
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				status.addEventListener = vi.fn()
-				status.removeEventListener = vi.fn()
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				const promise = getPermission('microphone', { signal: controller.signal })
@@ -246,8 +241,6 @@ describe('getPermission', () => {
 				const controller = new AbortController()
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				status.addEventListener = vi.fn()
-				status.removeEventListener = vi.fn()
 				// Abort synchronously inside the mock so signal is aborted when await resolves
 				mockPermissionsQuery.mockImplementationOnce(() => {
 					controller.abort()
@@ -278,9 +271,7 @@ describe('getPermission', () => {
 				const controller = new AbortController()
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
-				const mockRemoveEventListener = vi.fn()
-				status.addEventListener = vi.fn()
-				status.removeEventListener = mockRemoveEventListener
+				const removeEventListenerSpy = vi.spyOn(status, 'removeEventListener')
 				mockPermissionsQuery.mockResolvedValueOnce(status)
 
 				const promise = getPermission('microphone', { signal: controller.signal })
@@ -288,7 +279,7 @@ describe('getPermission', () => {
 				controller.abort()
 
 				await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
-				expect(mockRemoveEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+				expect(removeEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function))
 			})
 		})
 	})

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -1,6 +1,8 @@
 import getPermission from '../getPermission'
 import {
 	flushMicrotasks,
+	setNavigatorApiUnsupported,
+	restoreNavigatorApi,
 	setupPermissionsMock,
 	teardownPermissionsMock,
 	type MockPermissionStatus,
@@ -9,9 +11,8 @@ import {
 
 describe('getPermission', () => {
 	describe('navigator.permissions is not implemented', () => {
-		beforeAll(() => {
-			;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
-		})
+		beforeAll(() => setNavigatorApiUnsupported('permissions'))
+		afterAll(() => restoreNavigatorApi('permissions'))
 
 		it('rejects promise', async () => {
 			await expect(getPermission('microphone')).rejects.toMatchObject({

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -1,6 +1,8 @@
 import getUserMediaStream from '../getUserMediaStream'
 import {
 	flushMicrotasks,
+	setNavigatorApiUnsupported,
+	restoreNavigatorApi,
 	setupPermissionsMock,
 	teardownPermissionsMock,
 	setupMediaDevicesMock,
@@ -12,9 +14,8 @@ const FAKE_STREAM = {} as MediaStream
 
 describe('getUserMediaStream', () => {
 	describe('navigator.permissions is not implemented', () => {
-		beforeAll(() => {
-			;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
-		})
+		beforeAll(() => setNavigatorApiUnsupported('permissions'))
+		afterAll(() => restoreNavigatorApi('permissions'))
 
 		it('rejects promise', async () => {
 			await expect(getUserMediaStream('microphone', { audio: true })).rejects.toMatchObject({
@@ -32,9 +33,8 @@ describe('getUserMediaStream', () => {
 		afterAll(teardownPermissionsMock)
 
 		describe('navigator.mediaDevices is not implemented', () => {
-			beforeAll(() => {
-				;(globalThis.navigator as { mediaDevices?: MediaDevices }).mediaDevices = undefined
-			})
+			beforeAll(() => setNavigatorApiUnsupported('mediaDevices'))
+			afterAll(() => restoreNavigatorApi('mediaDevices'))
 
 			it('rejects promise', async () => {
 				await expect(getUserMediaStream('microphone', { audio: true })).rejects.toMatchObject({

--- a/src/__tests__/isNavigatorMediaDevicesSupported.test.ts
+++ b/src/__tests__/isNavigatorMediaDevicesSupported.test.ts
@@ -1,11 +1,16 @@
 import isNavigatorMediaDevicesSupported from '../isNavigatorMediaDevicesSupported'
-import { setupPermissionsMock, setupMediaDevicesMock, teardownPermissionsAndMediaDevicesMock } from './testUtils'
+import {
+	setNavigatorApiUnsupported,
+	restoreNavigatorApi,
+	setupPermissionsMock,
+	setupMediaDevicesMock,
+	teardownPermissionsAndMediaDevicesMock,
+} from './testUtils'
 
 describe('isNavigatorMediaDevicesSupported', () => {
 	describe('navigator.mediaDevices is not implemented', () => {
-		beforeAll(() => {
-			;(globalThis.navigator as { mediaDevices?: MediaDevices }).mediaDevices = undefined
-		})
+		beforeAll(() => setNavigatorApiUnsupported('mediaDevices'))
+		afterAll(() => restoreNavigatorApi('mediaDevices'))
 
 		it('returns false as permissions is not supported', async () => {
 			expect(isNavigatorMediaDevicesSupported()).toBeFalsy()

--- a/src/__tests__/isNavigatorMediaDevicesSupported.test.ts
+++ b/src/__tests__/isNavigatorMediaDevicesSupported.test.ts
@@ -2,16 +2,6 @@ import isNavigatorMediaDevicesSupported from '../isNavigatorMediaDevicesSupporte
 import { setupPermissionsMock, setupMediaDevicesMock, teardownPermissionsAndMediaDevicesMock } from './testUtils'
 
 describe('isNavigatorMediaDevicesSupported', () => {
-	describe('navigator.permissions is not implemented', () => {
-		beforeAll(() => {
-			;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
-		})
-
-		it('returns false as permissions is not supported', async () => {
-			expect(isNavigatorMediaDevicesSupported()).toBeFalsy()
-		})
-	})
-
 	describe('navigator.mediaDevices is not implemented', () => {
 		beforeAll(() => {
 			;(globalThis.navigator as { mediaDevices?: MediaDevices }).mediaDevices = undefined

--- a/src/__tests__/isNavigatorPermissionsSupported.test.ts
+++ b/src/__tests__/isNavigatorPermissionsSupported.test.ts
@@ -1,11 +1,15 @@
 import isNavigatorPermissionsSupported from '../isNavigatorPermissionsSupported'
-import { setupPermissionsMock, teardownPermissionsMock } from './testUtils'
+import {
+	setNavigatorApiUnsupported,
+	restoreNavigatorApi,
+	setupPermissionsMock,
+	teardownPermissionsMock,
+} from './testUtils'
 
 describe('isNavigatorPermissionsSupported', () => {
 	describe('navigator.permissions is not implemented', () => {
-		beforeAll(() => {
-			;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
-		})
+		beforeAll(() => setNavigatorApiUnsupported('permissions'))
+		afterAll(() => restoreNavigatorApi('permissions'))
 
 		it('returns false as permissions is not supported', async () => {
 			expect(isNavigatorPermissionsSupported()).toBeFalsy()

--- a/src/__tests__/testUtils.test.ts
+++ b/src/__tests__/testUtils.test.ts
@@ -1,0 +1,23 @@
+import { setNavigatorApiUnsupported, restoreNavigatorApi } from './testUtils'
+
+describe('testUtils', () => {
+	describe('stubProperty guard', () => {
+		it('throws when the same property is stubbed twice without restoring in between', () => {
+			// First stub captures the real original; the second would capture the stubbed value
+			// as the "original" and silently lose it, so it must fail loudly instead.
+			setNavigatorApiUnsupported('permissions')
+			try {
+				expect(() => setNavigatorApiUnsupported('permissions')).toThrow(/already stubbed/)
+			} finally {
+				restoreNavigatorApi('permissions')
+			}
+		})
+
+		it('allows stubbing again after the previous stub has been restored', () => {
+			setNavigatorApiUnsupported('permissions')
+			restoreNavigatorApi('permissions')
+			expect(() => setNavigatorApiUnsupported('permissions')).not.toThrow()
+			restoreNavigatorApi('permissions')
+		})
+	})
+})

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -10,32 +10,72 @@ export interface MockPermissionStatus {
 
 export type StatusChangeListener = (event: { target: { state: PermissionState } }) => void
 
+// Save/restore originals so the suite never leaks mutated globals between blocks.
+// Each `stubProperty` is paired with a matching `restoreProperty` (in an `afterAll`),
+// so we capture the current value before overwriting it and reinstate it on teardown —
+// restoring the real ambient value (often "not implemented") instead of forcing
+// `undefined`, which is what made the suite order-dependent.
+const restorers: Record<string, () => void> = {}
+
+const stubProperty = (target: object, key: string, value: unknown): void => {
+	const original = (target as Record<string, unknown>)[key]
+	restorers[key] = () => {
+		;(target as Record<string, unknown>)[key] = original
+	}
+	;(target as Record<string, unknown>)[key] = value
+}
+
+const restoreProperty = (key: string): void => {
+	restorers[key]()
+	delete restorers[key]
+}
+
+export const setNavigatorApiUnsupported = (api: 'permissions' | 'mediaDevices'): void => {
+	stubProperty(globalThis.navigator, api, undefined)
+}
+
+export const restoreNavigatorApi = (api: 'permissions' | 'mediaDevices'): void => {
+	restoreProperty(api)
+}
+
 export const setupPermissionsMock = (mockQuery: Mock): void => {
-	globalThis.PermissionStatus = vi.fn(function () {
-		return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
-	}) as unknown as typeof PermissionStatus
-	globalThis.Permissions = vi.fn(function () {
-		return { query: mockQuery }
-	}) as unknown as typeof Permissions
-	;(globalThis.navigator as { permissions?: Permissions }).permissions = new Permissions()
+	stubProperty(
+		globalThis,
+		'PermissionStatus',
+		vi.fn(function () {
+			return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
+		})
+	)
+	stubProperty(
+		globalThis,
+		'Permissions',
+		vi.fn(function () {
+			return { query: mockQuery }
+		})
+	)
+	stubProperty(globalThis.navigator, 'permissions', new Permissions())
 }
 
 export const teardownPermissionsMock = (): void => {
-	;(globalThis as { PermissionStatus?: typeof PermissionStatus }).PermissionStatus = undefined
-	;(globalThis as { Permissions?: typeof Permissions }).Permissions = undefined
-	;(globalThis.navigator as { permissions?: Permissions }).permissions = undefined
+	restoreProperty('permissions')
+	restoreProperty('Permissions')
+	restoreProperty('PermissionStatus')
 }
 
 export const setupMediaDevicesMock = (mockGetUserMedia: Mock): void => {
-	globalThis.MediaDevices = vi.fn(function () {
-		return { getUserMedia: mockGetUserMedia }
-	}) as unknown as typeof MediaDevices
-	;(globalThis.navigator as { mediaDevices?: MediaDevices }).mediaDevices = new MediaDevices()
+	stubProperty(
+		globalThis,
+		'MediaDevices',
+		vi.fn(function () {
+			return { getUserMedia: mockGetUserMedia }
+		})
+	)
+	stubProperty(globalThis.navigator, 'mediaDevices', new MediaDevices())
 }
 
 export const teardownMediaDevicesMock = (): void => {
-	;(globalThis as { MediaDevices?: typeof MediaDevices }).MediaDevices = undefined
-	;(globalThis.navigator as { mediaDevices?: MediaDevices }).mediaDevices = undefined
+	restoreProperty('mediaDevices')
+	restoreProperty('MediaDevices')
 }
 
 export const teardownPermissionsAndMediaDevicesMock = (): void => {

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -2,13 +2,13 @@ import type { Mock } from 'vitest'
 
 export const flushMicrotasks = (): Promise<void> => Promise.resolve()
 
-export interface MockPermissionStatus {
+// A real `EventTarget` (so `addEventListener` / `removeEventListener` / `dispatchEvent`
+// behave like the browser) carrying a mutable `state`. Prompt tests drive the genuine
+// async path by mutating `state` then dispatching a `change` event, rather than firing a
+// listener synchronously from inside a mocked `addEventListener`.
+export interface MockPermissionStatus extends EventTarget {
 	state: PermissionState
-	addEventListener: Mock
-	removeEventListener: Mock
 }
-
-export type StatusChangeListener = (event: { target: { state: PermissionState } }) => void
 
 // Save/restore originals so the suite never leaks mutated globals between blocks.
 // Each `stubProperty` is paired with a matching `restoreProperty` (in an `afterAll`),
@@ -42,9 +42,9 @@ export const setupPermissionsMock = (mockQuery: Mock): void => {
 	stubProperty(
 		globalThis,
 		'PermissionStatus',
-		vi.fn(function () {
-			return { state: 'granted', addEventListener: vi.fn(), removeEventListener: vi.fn() }
-		})
+		class extends EventTarget {
+			state: PermissionState = 'granted'
+		}
 	)
 	stubProperty(
 		globalThis,

--- a/src/__tests__/testUtils.ts
+++ b/src/__tests__/testUtils.ts
@@ -18,6 +18,12 @@ export interface MockPermissionStatus extends EventTarget {
 const restorers: Record<string, () => void> = {}
 
 const stubProperty = (target: object, key: string, value: unknown): void => {
+	// Single-slot map: stubbing an already-stubbed key would capture the *stubbed* value as
+	// the "original" and silently lose the real one, so restore would never reinstate it.
+	// Fail loudly instead — every `stubProperty` must be balanced by `restoreProperty` first.
+	if (key in restorers) {
+		throw new Error(`testUtils: "${key}" is already stubbed; restore it before stubbing it again.`)
+	}
 	const original = (target as Record<string, unknown>)[key]
 	restorers[key] = () => {
 		;(target as Record<string, unknown>)[key] = original


### PR DESCRIPTION
## Summary
Three test-hygiene fixes that make the suite order-independent and the `getPermission` prompt coverage faithful, with no change to the published library. Issue #130 predates the TypeScript migration and refers to `.js` paths; the work targets the current `.ts` test files.

## Changes
- **Remove a mislabeled test.** The first block in `isNavigatorMediaDevicesSupported.test.ts` set `navigator.permissions = undefined` and asserted the helper was falsy, but `isNavigatorMediaDevicesSupported` only reads `navigator.mediaDevices`. It passed by jsdom accident and duplicated the next block's real coverage.
- **Restore original navigator globals instead of nulling them.** The shared mock helpers reset `navigator.permissions` / `navigator.mediaDevices` and the `Permissions` / `MediaDevices` globals to `undefined` on teardown, and the "not implemented" `describe` blocks mutated `navigator` in `beforeAll` with no matching `afterAll`. Correctness relied on source order plus jsdom defaults. Helpers now capture each property's current value and reinstate it on teardown, and a `setNavigatorApiUnsupported` / `restoreNavigatorApi` pair gives every "not implemented" block a matching `afterAll`. `stubProperty` also throws if a key is stubbed twice without an intervening restore, so an unbalanced stub fails loudly instead of silently capturing the stub as the "original".
- **Drive the prompt tests through a real `EventTarget`.** The `PermissionStatus` mock fired the `change` callback synchronously from inside a mocked `addEventListener`, so the genuine async wait — and the abort-listener cleanup ordering in `getPermission` — was never exercised. `PermissionStatus` is now a real `EventTarget` carrying a mutable `state`; prompt/abort tests mutate `state` then `dispatchEvent(new Event('change'))` and spy on `add`/`removeEventListener` for the cleanup assertions.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn test:ci` — 44 passing, coverage 100% (statements/branches/functions/lines)
- [x] `yarn lint` — clean
- [x] `yarn build` — succeeds
- [x] No production code touched; only files under `src/__tests__/`

Closes #130
