### PR TITLE
fix: Stop late-resolving MediaStream tracks when getUserMediaStream is aborted

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const init = async () => {
 
 `getUserMediaStream`:
 
-Returns a promise resolved when the permission is granted and the stream is retrieved. Accepts an optional `signal` to cancel the entire operation.
+Returns a promise resolved when the permission is granted and the stream is retrieved. Accepts an optional `signal` to cancel the entire operation. If the signal aborts while acquisition is still in flight, a stream that resolves afterwards is torn down automatically (its tracks are stopped), so the camera or microphone is never left active.
 
 The `permissionName` and `mediaStreamConstraints` must match the same media device:
 

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -246,9 +246,10 @@ describe('getUserMediaStream', () => {
 						await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
 
 						// `getUserMedia()` rejects *after* the race already settled. `Promise.race` itself
-						// consumes `mediaPromise`'s rejection, so this specifically guards the guard chain's
-						// own `.catch(() => {})` sink (complementary to the track-stop test above, which guards
-						// the teardown body): without `.catch`, `mediaPromise.then(...)` leaks an unhandled rejection.
+						// consumes `mediaPromise`'s rejection, so this specifically guards the teardown's own
+						// `catch` sink (complementary to the track-stop test above, which guards the teardown
+						// body): without the `catch`, `await mediaPromise` would rethrow and leak an unhandled
+						// rejection.
 						rejectStream(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
 						await new Promise<void>((resolve) => setTimeout(resolve, 0))
 

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -177,6 +177,86 @@ describe('getUserMediaStream', () => {
 						getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
 					).resolves.toBe(FAKE_STREAM)
 				})
+
+				it('stops the tracks of a stream that resolves after the abort', async () => {
+					const controller = new AbortController()
+					const status = new PermissionStatus() as unknown as MockPermissionStatus
+					status.state = 'granted'
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+
+					// A faithful stream mock whose track exposes a `stop` spy — the plain
+					// `FAKE_STREAM` used elsewhere has no `getTracks()`, so it cannot witness the leak.
+					const stop = vi.fn()
+					const lateStream = {
+						getTracks: () => [{ stop } as unknown as MediaStreamTrack],
+					} as unknown as MediaStream
+					let resolveStream!: (stream: MediaStream) => void
+					mockMediaDevicesGetUserMedia.mockImplementationOnce(
+						() =>
+							new Promise<MediaStream>((resolve) => {
+								resolveStream = resolve
+							})
+					)
+
+					const promise = getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					await flushMicrotasks()
+					controller.abort()
+
+					await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+
+					// `getUserMedia()` resolves *after* the abort: the orphaned stream must be torn down.
+					// Observe the teardown across a macrotask boundary — the guard runs on a microtask off
+					// `mediaPromise`, and a single microtask tick proved timing-fragile here.
+					resolveStream(lateStream)
+					await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+					expect(stop).toHaveBeenCalledOnce()
+				})
+
+				it('does not raise an unhandled rejection when getUserMedia rejects after the abort', async () => {
+					const controller = new AbortController()
+					const status = new PermissionStatus() as unknown as MockPermissionStatus
+					status.state = 'granted'
+					mockPermissionsQuery.mockResolvedValueOnce(status)
+
+					let rejectStream!: (reason: unknown) => void
+					mockMediaDevicesGetUserMedia.mockImplementationOnce(
+						() =>
+							new Promise<MediaStream>((_, reject) => {
+								rejectStream = reject
+							})
+					)
+
+					// `process` is a Node global absent from the DOM-only typings, reached via `globalThis`.
+					const proc = (
+						globalThis as unknown as {
+							process: {
+								on(event: 'unhandledRejection', listener: (reason: unknown) => void): void
+								off(event: 'unhandledRejection', listener: (reason: unknown) => void): void
+							}
+						}
+					).process
+					const onUnhandled = vi.fn()
+					proc.on('unhandledRejection', onUnhandled)
+					try {
+						const promise = getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+						await flushMicrotasks()
+						controller.abort()
+
+						await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+
+						// `getUserMedia()` rejects *after* the race already settled. `Promise.race` itself
+						// consumes `mediaPromise`'s rejection, so this specifically guards the guard chain's
+						// own `.catch(() => {})` sink (complementary to the track-stop test above, which guards
+						// the teardown body): without `.catch`, `mediaPromise.then(...)` leaks an unhandled rejection.
+						rejectStream(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+						await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+						expect(onUnhandled).not.toHaveBeenCalled()
+					} finally {
+						proc.off('unhandledRejection', onUnhandled)
+					}
+				})
 			})
 		})
 	})

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -37,14 +37,10 @@ const getUserMediaStream = async (
 	const mediaPromise = navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
 	if (!signal) return mediaPromise
 
-	// `getUserMedia()` has no native cancellation and `Promise.race` does not cancel the
-	// losing promise: when the signal aborts while `getUserMedia()` is still pending, the race
-	// below rejects with `signal.reason` but `mediaPromise` keeps running. Should it later
-	// resolve with a live stream, the caller already holds the rejection — and no reference to
-	// the stream — so nothing would stop its tracks and the camera/microphone would stay
-	// active. Tear the orphaned stream down once it settles. This cannot be awaited inline: the
-	// caller must receive the abort rejection from the race immediately, not after the slow
-	// `getUserMedia()` finally settles — so it runs detached, fire-and-forget.
+	// `Promise.race` does not cancel the loser: if the signal aborts while `getUserMedia()` is
+	// still pending, the race rejects but `mediaPromise` keeps running and may resolve a stream
+	// the caller never sees — leaving the camera/microphone live. Stop its tracks once it
+	// settles, detached so the caller still receives the abort rejection immediately.
 	const teardownIfAborted = async () => {
 		try {
 			const stream = await mediaPromise
@@ -52,8 +48,7 @@ const getUserMediaStream = async (
 				stream.getTracks().forEach((track) => track.stop())
 			}
 		} catch {
-			// Once the race has settled with the abort, this is `mediaPromise`'s only remaining
-			// consumer: swallow a late rejection so it never surfaces as an unhandled rejection.
+			// Swallow a late rejection so it never surfaces as unhandled once the race has settled.
 		}
 	}
 	void teardownIfAborted()

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -42,16 +42,21 @@ const getUserMediaStream = async (
 	// below rejects with `signal.reason` but `mediaPromise` keeps running. Should it later
 	// resolve with a live stream, the caller already holds the rejection — and no reference to
 	// the stream — so nothing would stop its tracks and the camera/microphone would stay
-	// active. Guard the resolution to tear the orphaned stream down. The trailing
-	// `.catch(() => {})` also swallows a late rejection so it never surfaces as an unhandled
-	// rejection once the race has already settled.
-	mediaPromise
-		.then((stream) => {
+	// active. Tear the orphaned stream down once it settles. This cannot be awaited inline: the
+	// caller must receive the abort rejection from the race immediately, not after the slow
+	// `getUserMedia()` finally settles — so it runs detached, fire-and-forget.
+	const teardownIfAborted = async () => {
+		try {
+			const stream = await mediaPromise
 			if (signal.aborted) {
 				stream.getTracks().forEach((track) => track.stop())
 			}
-		})
-		.catch(() => {})
+		} catch {
+			// Once the race has settled with the abort, this is `mediaPromise`'s only remaining
+			// consumer: swallow a late rejection so it never surfaces as an unhandled rejection.
+		}
+	}
+	void teardownIfAborted()
 
 	let onAbort!: () => void
 	const abortPromise = new Promise<never>((_, reject) => {

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -37,6 +37,22 @@ const getUserMediaStream = async (
 	const mediaPromise = navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
 	if (!signal) return mediaPromise
 
+	// `getUserMedia()` has no native cancellation and `Promise.race` does not cancel the
+	// losing promise: when the signal aborts while `getUserMedia()` is still pending, the race
+	// below rejects with `signal.reason` but `mediaPromise` keeps running. Should it later
+	// resolve with a live stream, the caller already holds the rejection — and no reference to
+	// the stream — so nothing would stop its tracks and the camera/microphone would stay
+	// active. Guard the resolution to tear the orphaned stream down. The trailing
+	// `.catch(() => {})` also swallows a late rejection so it never surfaces as an unhandled
+	// rejection once the race has already settled.
+	mediaPromise
+		.then((stream) => {
+			if (signal.aborted) {
+				stream.getTracks().forEach((track) => track.stop())
+			}
+		})
+		.catch(() => {})
+
 	let onAbort!: () => void
 	const abortPromise = new Promise<never>((_, reject) => {
 		onAbort = () => reject(signal.reason)


### PR DESCRIPTION
## Summary
When `getUserMediaStream` is aborted while `getUserMedia()` is still in flight, the caller correctly receives `AbortError` — but the underlying device could stay active. `Promise.race([mediaPromise, abortPromise])` does not cancel the losing promise, so a `MediaStream` that resolved *after* the abort was orphaned and its tracks were never stopped (camera LED stays lit / mic keeps capturing). There was also a latent unhandled-rejection risk if the media promise rejected late.

This guards the media promise: once the signal is aborted, any stream it later yields has its tracks stopped, and a trailing `.catch(() => {})` absorbs a late rejection. The normal (non-aborted) resolution is unchanged — the caller still receives the same stream from the race.

Ships together with the companion regression tests (#125): the previous "abort during getUserMedia" test used a never-resolving mock, so the leak was untested despite 100% coverage.

## Changes
- `src/getUserMediaStream.ts` — attach a resolution guard to the media promise that stops every track when `signal.aborted`, with a `.catch(() => {})` that also swallows a late rejection.
- `src/__tests__/getUserMediaStream.test.ts` — two regression tests:
  - a faithful stream mock (`getTracks()` → track with a `stop()` spy) resolving **after** `controller.abort()`, asserting the tracks are stopped;
  - a sibling test asserting no unhandled rejection when `getUserMedia()` rejects after the abort (guards the `.catch` sink).
- `README.md` — note that aborting tears down a late-resolving stream.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:ci` — 46 tests pass, 100% coverage (statements/branches/functions/lines)
- [x] `yarn lint`
- [x] `yarn build`
- [x] Stress-ran the teardown test 30× across fresh processes (no flakes) after replacing a microtask tick with a macrotask boundary for the teardown assertion

## Breaking changes
None — the signature and `GetUserMediaStreamOptions` are unchanged; the teardown is internal and unobservable to a caller who only ever received the rejection.

Closes #124
Closes #125