### PR TITLE
fix: Surface the prompt when a permission name is not queryable (Firefox/Safari)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Bibliothèque utilitaire légère (~5 fonctions) écrite en **TypeScript**, qui 
 ```
 getUserMediaStream
   └── garde inline `!navigator.permissions || !navigator.mediaDevices` (lève NOT_SUPPORTED_ERR)
-  └── navigator.permissions.query()         (rejette si 'denied')
+  └── navigator.permissions.query()         (rejette si 'denied' ; un TypeError de nom non interrogeable est avalé → fallthrough vers getUserMedia)
   └── navigator.mediaDevices.getUserMedia() (Promise.race avec le signal, uniquement si fourni)
 
 getPermission
@@ -44,7 +44,7 @@ checkPermission
 - Chaque point d'entrée vérifie **en ligne** l'existence de l'API navigateur (`!navigator.permissions`, plus `!navigator.mediaDevices` pour `getUserMediaStream`) et lève `NOT_SUPPORTED_ERR` si elle est absente. Il n'y a **pas** de helper `is…Supported` exporté : la détection de support côté consommateur passe par `checkPermission` (qui rejette/propage l'erreur de `query()`).
 - `getPermission(permissionName, { signal?, timeout? })` : watcher **passif** qui résout sur `'granted'` une fois la permission accordée. `navigator.permissions.query()` n'affiche **jamais** de dialogue : `'granted'` résout immédiatement, `'denied'` rejette (`NOT_ALLOWED_ERR`). Sur `'prompt'`, attend l'événement `change` (déclenché seulement quand autre chose provoque la vraie requête, ex. `getUserMediaStream`) ; comme rien ne fait transitionner l'état tout seul, l'attente doit être **bornée** par `timeout` (rejette `TimeoutError`) et/ou `signal`. Sans aucune des deux sur `'prompt'`, rejette immédiatement (`InvalidStateError`) au lieu de rester pendante à jamais. Le listener `change` est nettoyé sur tous les chemins de résolution.
 - `checkPermission(permissionName)` : retourne une Promise résolue immédiatement avec l'état courant de la permission (`'granted'` / `'denied'` / `'prompt'`), sans attendre d'interaction utilisateur ni rejeter sur `'denied'`. Passe par la même garde inline `!navigator.permissions` que `getPermission`. Utile pour lire l'état en amont (bannière, bouton désactivé, branchement UI).
-- `getUserMediaStream(permissionName, mediaStreamConstraints, { signal? })` : appelle directement `navigator.permissions.query()` (rejette si `'denied'`) puis `navigator.mediaDevices.getUserMedia()` — c'est `getUserMedia` qui déclenche le vrai dialogue. N'appelle **pas** `getPermission` et n'est donc pas concerné par le contrat d'attente bornée ; l'`AbortSignal` n'est géré via `Promise.race` que lorsqu'un `signal` est fourni, sinon la promesse de `getUserMedia` est renvoyée directement.
+- `getUserMediaStream(permissionName, mediaStreamConstraints, { signal? })` : appelle directement `navigator.permissions.query()` (rejette si `'denied'`) puis `navigator.mediaDevices.getUserMedia()` — c'est `getUserMedia` qui déclenche le vrai dialogue. N'appelle **pas** `getPermission` et n'est donc pas concerné par le contrat d'attente bornée ; l'`AbortSignal` n'est géré via `Promise.race` que lorsqu'un `signal` est fourni, sinon la promesse de `getUserMedia` est renvoyée directement. Le `query()` est enveloppé dans un `try/catch` : un `TypeError` (nom de permission non interrogeable, ex. Firefox/Safari pour `camera`/`microphone`/`midi`) est avalé et le flux retombe sur l'API native ; toute autre erreur se propage. Le chemin actif `_acquirePermission` (getters caméra/micro/midi…) applique le même fallthrough, en traitant le `TypeError` comme `'prompt'` pour déclencher le trigger.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ const init = async () => {
 
 > **Pass a `timeout` for unattended flows.** Unlike the passive getters (and `getPermission`), the active getters don't require `signal`/`timeout` on `'prompt'` — the native prompt they surface settles the wait when the user responds. But if the user neither accepts nor dismisses, the wait lasts as long as the prompt does. Add a `timeout` (and/or `signal`) whenever you can't rely on a timely response.
 
+> **Non-queryable permission names fall through to the native API.** Some browsers support a device but reject `navigator.permissions.query()` for its name with a `TypeError` (e.g. Firefox / Safari for `camera`, `microphone`, `midi`). The active getters and `getUserMediaStream` catch that and surface the prompt through the native API anyway (`getUserMedia`, `requestMIDIAccess`, …) instead of failing, so they work cross-browser. The passive getters and `checkPermission` have no native trigger to fall back on, so they still propagate the `query()` error.
+
 **Passive getters** only _watch_ the state (exactly like `getPermission`) and never surface a dialog, because the library cannot trigger them from a permission name alone without consumer-owned infrastructure or a privacy-sensitive side effect. The **bounded-wait** requirement on `'prompt'` therefore applies (pass `signal` and/or `timeout`):
 
 | Function                      | Permission name     | Why it stays passive                                        |

--- a/src/__tests__/_acquirePermission.test.ts
+++ b/src/__tests__/_acquirePermission.test.ts
@@ -83,6 +83,19 @@ describe('acquirePermission', () => {
 			await expect(acquirePermission('camera', vi.fn())).rejects.toEqual(new Error('ERR'))
 		})
 
+		// `query()` throws a `TypeError` for a permission name the browser won't query (Firefox/Safari:
+		// camera/microphone/midi) even though the trigger's native API works. Treat it as `'prompt'` so
+		// the trigger still surfaces the real dialog instead of leaking the `TypeError`.
+		it('treats a non-queryable name (query throws TypeError) as "prompt" and fires the trigger', async () => {
+			mockPermissionsQuery.mockImplementationOnce(() => {
+				throw new TypeError("'camera' is not a valid enum value of type PermissionName")
+			})
+			const trigger = vi.fn().mockResolvedValueOnce(undefined)
+
+			await expect(acquirePermission('camera', trigger)).resolves.toBe('granted')
+			expect(trigger).toHaveBeenCalledOnce()
+		})
+
 		describe('AbortSignal', () => {
 			it('rejects immediately when the signal is already aborted, before querying', async () => {
 				const controller = new AbortController()

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -108,6 +108,34 @@ describe('getUserMediaStream', () => {
 				await expect(getUserMediaStream('microphone', { audio: true })).rejects.toEqual(new Error('ERR'))
 			})
 
+			describe('permission name not queryable (Firefox/Safari)', () => {
+				// `query()` throws a `TypeError` for a device the browser supports through `getUserMedia`
+				// but won't let you query (Firefox: camera/microphone). The call must fall through to
+				// `getUserMedia` rather than leaking the `TypeError`.
+				it('falls through to getUserMedia when query throws a TypeError', async () => {
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						throw new TypeError("'camera' is not a valid enum value of type PermissionName")
+					})
+					mockMediaDevicesGetUserMedia.mockResolvedValueOnce(FAKE_STREAM)
+
+					await expect(getUserMediaStream('camera', { video: true })).resolves.toBe(FAKE_STREAM)
+					expect(mockMediaDevicesGetUserMedia).toHaveBeenCalledWith({ video: true })
+				})
+
+				it('lets getUserMedia surface a denial when query is not queryable', async () => {
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						throw new TypeError("'camera' is not a valid enum value of type PermissionName")
+					})
+					mockMediaDevicesGetUserMedia.mockRejectedValueOnce(
+						new DOMException('Permission denied', 'NotAllowedError')
+					)
+
+					await expect(getUserMediaStream('camera', { video: true })).rejects.toMatchObject({
+						name: 'NotAllowedError',
+					})
+				})
+			})
+
 			describe('AbortSignal', () => {
 				it('rejects immediately when signal is already aborted', async () => {
 					const controller = new AbortController()

--- a/src/_acquirePermission.ts
+++ b/src/_acquirePermission.ts
@@ -35,14 +35,24 @@ const acquirePermission = async (
 
 	signal?.throwIfAborted()
 
-	const permissionStatus = await navigator.permissions.query({ name: permissionName })
+	// Browsers that can't query this permission name (Firefox/Safari: `camera`/`microphone`/`midi`)
+	// throw a `TypeError` even though the trigger's native API works. Treat that as `'prompt'` so the
+	// trigger still surfaces the real dialog; any other query error propagates unchanged.
+	let state: PermissionState = 'prompt'
+	try {
+		state = (await navigator.permissions.query({ name: permissionName })).state
+	} catch (error) {
+		if (!(error instanceof TypeError)) {
+			throw error
+		}
+	}
 
 	signal?.throwIfAborted()
 
-	if (permissionStatus.state === 'granted') {
+	if (state === 'granted') {
 		return 'granted'
 	}
-	if (permissionStatus.state === 'denied') {
+	if (state === 'denied') {
 		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
 	}
 

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -23,9 +23,20 @@ const getUserMediaStream = async (
 
 	signal?.throwIfAborted()
 
-	const permissionStatus = await navigator.permissions.query({ name: permissionName })
+	// `query()` only lets us short-circuit a prior denial. Browsers that support the device but not
+	// querying its permission name (Firefox/Safari: `camera`/`microphone`) throw a `TypeError` here —
+	// fall through to `getUserMedia`, the real authority, which surfaces the prompt or rejects on its
+	// own. Any other query error propagates unchanged.
+	let denied = false
+	try {
+		denied = (await navigator.permissions.query({ name: permissionName })).state === 'denied'
+	} catch (error) {
+		if (!(error instanceof TypeError)) {
+			throw error
+		}
+	}
 
-	if (permissionStatus.state === 'denied') {
+	if (denied) {
 		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
 	}
 


### PR DESCRIPTION
## Summary
`getUserMediaStream` and the active getters call `navigator.permissions.query()` before doing anything else. On browsers that support a device but won't let you query its permission name (Firefox / Safari for `camera`, `microphone`, `midi`), `query()` throws a `TypeError`, so the active path leaked that error instead of surfacing the real prompt — defeating the library's headline use case on non-Chromium browsers. This wraps the query and falls through to the native API on a `TypeError`.

## Changes
- `getUserMediaStream` wraps `query()`: on a `TypeError` it skips the `'denied'` short-circuit and proceeds to `getUserMedia` (the real authority); any other query error still propagates.
- `_acquirePermission` wraps `query()`: on a `TypeError` it treats the state as `'prompt'` and fires the native trigger; any other query error still propagates. This covers `getCameraPermission`, `getMicrophonePermission`, `getMidiPermission`, etc.
- Regression tests for both paths (TypeError → fall through / fire trigger; non-`TypeError` errors keep propagating). Coverage stays at 100%.
- Docs: README "Feature detection" note + `CLAUDE.md` flow description updated.

Passive getters (`getPushPermission`, `getClipboard*Permission`) and `checkPermission` are intentionally unchanged: with no native trigger to fall back on, they still propagate the `query()` error.

## Test plan
- [ ] `yarn test:ci` — 134 tests pass, 100% coverage
- [ ] `yarn typecheck` / `yarn lint` / `yarn build` all green
- [ ] Manual (Firefox): `getCameraPermission()` / `getUserMediaStream('camera', { video: true })` now surface the prompt instead of rejecting with a `TypeError`
- [ ] Manual (Chromium): no behavior change — query still short-circuits `granted`/`denied`

Closes #144