### PR TITLE
fix: Honour an abort before the denied check in getUserMediaStream

### DIFF
--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -170,6 +170,23 @@ describe('getUserMediaStream', () => {
 					expect(mockAcquireMediaStream).not.toHaveBeenCalled()
 				})
 
+				it("gives the abort precedence over a 'denied' state (AbortError, not NOT_ALLOWED_ERR)", async () => {
+					// An abort landing while the query settles on a previously-denied permission must reject
+					// with `AbortError`, consistent with `getPermission` / `acquirePermission` (issue #145).
+					const controller = new AbortController()
+					const status = new PermissionStatus() as unknown as MockPermissionStatus
+					status.state = 'denied'
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						controller.abort()
+						return Promise.resolve(status)
+					})
+
+					await expect(
+						getUserMediaStream('microphone', { audio: true }, { signal: controller.signal })
+					).rejects.toMatchObject({ name: 'AbortError' })
+					expect(mockAcquireMediaStream).not.toHaveBeenCalled()
+				})
+
 				it('forwards the signal to acquireMediaStream', async () => {
 					const controller = new AbortController()
 					const status = new PermissionStatus() as unknown as MockPermissionStatus

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -171,8 +171,6 @@ describe('getUserMediaStream', () => {
 				})
 
 				it("gives the abort precedence over a 'denied' state (AbortError, not NOT_ALLOWED_ERR)", async () => {
-					// An abort landing while the query settles on a previously-denied permission must reject
-					// with `AbortError`, consistent with `getPermission` / `acquirePermission` (issue #145).
 					const controller = new AbortController()
 					const status = new PermissionStatus() as unknown as MockPermissionStatus
 					status.state = 'denied'

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -38,11 +38,14 @@ const getUserMediaStream = async (
 		}
 	}
 
+	// Give the abort precedence over the denied short-circuit, matching `getPermission` /
+	// `acquirePermission`: an abort that lands while the query settles rejects with `AbortError`,
+	// not `NOT_ALLOWED_ERR`.
+	signal?.throwIfAborted()
+
 	if (denied) {
 		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
 	}
-
-	signal?.throwIfAborted()
 
 	// The `getUserMedia` call (and its abort teardown) lives in `acquireMediaStream`, which the
 	// camera/microphone triggers reuse directly so the active getters never re-query the permission.

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -38,9 +38,6 @@ const getUserMediaStream = async (
 		}
 	}
 
-	// Give the abort precedence over the denied short-circuit, matching `getPermission` /
-	// `acquirePermission`: an abort that lands while the query settles rejects with `AbortError`,
-	// not `NOT_ALLOWED_ERR`.
 	signal?.throwIfAborted()
 
 	if (denied) {


### PR DESCRIPTION
## Summary
In `getUserMediaStream`, an `AbortSignal` aborted while `navigator.permissions.query()` is resolving rejected with `NOT_ALLOWED_ERR` when the resolved state was `'denied'`, instead of `AbortError`. `getPermission` and `acquirePermission` give the abort priority in the same situation, so the three entry points disagreed.

The fix moves the post-query `signal?.throwIfAborted()` ahead of the `'denied'` short-circuit, restoring the shared `query → throwIfAborted → evaluate state` ordering. An abort that lands while the query settles now rejects with `AbortError` consistently across `getUserMediaStream`, `getPermission` and `acquirePermission`.

## Changes
- `src/getUserMediaStream.ts` — move `signal?.throwIfAborted()` before the `if (denied)` branch (one-line reorder; no other logic change).
- `src/__tests__/getUserMediaStream.test.ts` — add a regression test: when the signal aborts as a `'denied'` query settles, the call rejects with `AbortError` (not `NOT_ALLOWED_ERR`) and never delegates to `acquireMediaStream`.

## Test plan
- [ ] `yarn typecheck` passes
- [ ] `yarn test:ci` passes (138 tests, 100% coverage retained)
- [ ] `yarn build` succeeds
- [ ] `yarn lint` clean
- [ ] New test fails on the old ordering and passes on the new one

Closes #145