### PR TITLE
docs: Remove the "## Todos" roadmap section from the published README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,3 @@ To launch the interactive demo (Vite dev server) and exercise the utilities agai
 ```bash
 yarn dev
 ```
-
-## Todos
-
-- Extend the dedicated permission getters to sensor/device permissions (`accelerometer`, `bluetooth`, `gyroscope`, `magnetometer`, …) once they land in the DOM `PermissionName` type


### PR DESCRIPTION
## Summary
Removes the trailing `## Todos` roadmap section from `README.md`. That section was published verbatim on the npm package page and the GitHub landing page, mixing an internal roadmap item with consumer-facing documentation. The readme now ends cleanly on the `## Development` section.

## Changes
- Drop the `## Todos` heading and its single sensor/device-permissions bullet from `README.md` (no companion tracking issue created, per request).

## Test plan
- [ ] Confirm the published readme no longer renders a Todos section
- [ ] `README.md` ends on the `## Development` / `yarn dev` block with a single trailing newline
- [ ] No source/demo/test impact — pre-commit suite (typecheck + 138 tests / 100% coverage + lint + prettier) stays green

Closes #147