### PR TITLE
fix: Remove the change listener when watchPermission's upfront emit throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ const init = async () => {
 }
 ```
 
-The subscription lives until the optional `signal` aborts, at which point the `change` listener is removed. Omit the `signal` for a watch that lasts the page's lifetime.
+The subscription lives until the optional `signal` aborts, at which point the `change` listener is removed. Omit the `signal` for a watch that lasts the page's lifetime. If your `onChange` throws on the upfront emit, the returned promise rejects and the `change` listener is removed first, so a throwing emit never leaves a subscription behind.
 
 ```javascript
 import { watchPermission } from '@untemps/user-permissions-utils'

--- a/src/__tests__/watchPermission.test.ts
+++ b/src/__tests__/watchPermission.test.ts
@@ -96,6 +96,52 @@ describe('watchPermission', () => {
 			await expect(watchPermission('microphone', vi.fn())).rejects.toEqual(new Error('ERR'))
 		})
 
+		describe('when the upfront emit throws', () => {
+			it('removes the change listener before rejecting so no subscription is left behind', async () => {
+				const status = new PermissionStatus() as unknown as MockPermissionStatus
+				status.state = 'prompt'
+				const removeEventListenerSpy = vi.spyOn(status, 'removeEventListener')
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				const error = new Error('boom')
+				const onChange = vi.fn(() => {
+					throw error
+				})
+
+				await expect(watchPermission('microphone', onChange)).rejects.toBe(error)
+				expect(removeEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function))
+
+				// A later change must not reach the now-removed listener
+				onChange.mockReset()
+				status.state = 'granted'
+				status.dispatchEvent(new Event('change'))
+				expect(onChange).not.toHaveBeenCalled()
+			})
+
+			it('removes the abort listener too so a later abort triggers no further teardown', async () => {
+				const controller = new AbortController()
+				const status = new PermissionStatus() as unknown as MockPermissionStatus
+				status.state = 'prompt'
+				const removeEventListenerSpy = vi.spyOn(status, 'removeEventListener')
+				mockPermissionsQuery.mockResolvedValueOnce(status)
+
+				const onChange = vi.fn(() => {
+					throw new Error('boom')
+				})
+
+				await expect(watchPermission('microphone', onChange, { signal: controller.signal })).rejects.toThrow(
+					'boom'
+				)
+
+				// Teardown ran exactly once (the upfront-throw path), removing the change listener
+				expect(removeEventListenerSpy).toHaveBeenCalledTimes(1)
+
+				// Aborting afterwards must not fire the abort handler again (it was unsubscribed)
+				controller.abort()
+				expect(removeEventListenerSpy).toHaveBeenCalledTimes(1)
+			})
+		})
+
 		describe('AbortSignal', () => {
 			it('rejects immediately when signal is already aborted and never queries', async () => {
 				const controller = new AbortController()

--- a/src/watchPermission.ts
+++ b/src/watchPermission.ts
@@ -21,6 +21,10 @@ export interface WatchPermissionOptions {
  * the subscription is active is a silent teardown — the returned promise has already resolved, so it
  * is not rejected; only an abort *before* the subscription is active rejects with `AbortError`.
  *
+ * If the upfront emit throws (a consumer `onChange` that rejects synchronously), the `change` and
+ * abort listeners are removed before the returned promise rejects, so a throwing emit never leaves a
+ * zombie subscription behind.
+ *
  * @param permissionName            Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
  * @param onChange                  Called with the permission state on each transition (and once upfront unless `emitImmediately` is `false`)
  * @param options                   Optional settings
@@ -49,11 +53,20 @@ const watchPermission = async (
 	// regardless of order — subscribing first is defensive, covering only a transition that `onChange`
 	// itself might trigger. The abort listener removes the `change` listener on teardown (no leak).
 	const listener = () => onChange(permissionStatus.state)
+	const onAbort = () => permissionStatus.removeEventListener('change', listener)
 	permissionStatus.addEventListener('change', listener)
-	signal?.addEventListener('abort', () => permissionStatus.removeEventListener('change', listener), { once: true })
+	signal?.addEventListener('abort', onAbort, { once: true })
 
 	if (emitImmediately) {
-		onChange(permissionStatus.state)
+		try {
+			onChange(permissionStatus.state)
+		} catch (error) {
+			// The `change` listener is already registered; tear it (and the abort listener) down before
+			// rejecting so a throwing upfront emit never leaves a zombie subscription behind.
+			permissionStatus.removeEventListener('change', listener)
+			signal?.removeEventListener('abort', onAbort)
+			throw error
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
`watchPermission` registered the `change` listener (and wired the abort teardown) **before** running the upfront `onChange` emit, with no `try/catch` around that synchronous call. If a consumer's `onChange` threw during the upfront emit, the returned promise rejected but the already-registered `change` listener was never removed — a zombie subscription that kept invoking the throwing callback on every future transition, with nothing able to remove it unless an abort `signal` had been provided.

The fix wraps the upfront emit in a `try/catch` that removes both the `change` and abort listeners before re-throwing, so a throwing emit never leaves a subscription behind. The contract is unchanged: the promise still rejects with the consumer's error.

## Changes
- `src/watchPermission.ts` — extract the abort handler into a named `onAbort` const (so it can be removed on the failure path); wrap the upfront `onChange` emit in `try/catch` that calls `removeEventListener('change', …)` + `signal?.removeEventListener('abort', onAbort)` then re-throws. JSDoc updated to document the cleanup.
- `src/__tests__/watchPermission.test.ts` — add a `when the upfront emit throws` block: (1) the change listener is removed before the promise rejects and a later `change` never reaches the now-removed listener; (2) the abort listener is removed too, so a later `abort()` triggers no further teardown.
- `README.md` — document that a throwing upfront emit rejects with the listener already cleaned up.

## Scope note
The issue also flagged, as *optional*, isolating `onChange` errors on **later** transitions. While investigating I confirmed that a throw on a later transition does **not** break the watch — `dispatchEvent` already isolates listener errors (the listener stays registered) in both jsdom and real browsers, so the only effect of wrapping the listener would be suppressing the browser's global error report of a consumer bug. That behavior is not observable in jsdom (so it can't be pinned by a regression test) and silently swallowing would hide consumer errors, so this PR intentionally scopes to the actual reported leak.

## Test plan
- [ ] `yarn typecheck` passes
- [ ] `yarn test:ci` passes (140 tests, 100% coverage retained)
- [ ] `yarn lint` clean
- [ ] `yarn build` succeeds
- [ ] New tests fail on the old code path (listener leaks) and pass on the fix

Closes #152