### PR TITLE
docs: Trim watchPermission upfront-emit listener comments

### DIFF
--- a/src/watchPermission.ts
+++ b/src/watchPermission.ts
@@ -48,10 +48,6 @@ const watchPermission = async (
 
 	signal?.throwIfAborted()
 
-	// Register the `change` listener before the upfront emit. There is no async gap between
-	// `query()` resolving and this synchronous block, so the browser can't slip a `change` event in
-	// regardless of order — subscribing first is defensive, covering only a transition that `onChange`
-	// itself might trigger. The abort listener removes the `change` listener on teardown (no leak).
 	const listener = () => onChange(permissionStatus.state)
 	const onAbort = () => permissionStatus.removeEventListener('change', listener)
 	permissionStatus.addEventListener('change', listener)
@@ -61,8 +57,6 @@ const watchPermission = async (
 		try {
 			onChange(permissionStatus.state)
 		} catch (error) {
-			// The `change` listener is already registered; tear it (and the abort listener) down before
-			// rejecting so a throwing upfront emit never leaves a zombie subscription behind.
 			permissionStatus.removeEventListener('change', listener)
 			signal?.removeEventListener('abort', onAbort)
 			throw error


### PR DESCRIPTION
## Summary
Follow-up to #155 (merged, released as `2.0.0-beta.13`). That PR added two block comments to `watchPermission` explaining why the `change` listener is registered before the upfront emit and why it's torn down when the emit throws. They're more verbose than the code needs — the listener registration, abort wiring, and the `try/catch` teardown are already self-evident — so this trims them.

## Changes
- Remove the comment above the `change`/`abort` listener registration in `watchPermission`.
- Remove the comment inside the `emitImmediately` `try/catch` teardown block.

No behavior change — comments only.

## Test plan
- [x] `yarn typecheck`, `yarn lint`, `yarn test:ci`, and Prettier check all green
- [x] No logic touched; the upfront-emit teardown behavior (and its tests added in #155) is unchanged

## Breaking changes
None.