### PR TITLE
fix!: Standardize DOMException error names (NotAllowedError/NotSupportedError)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,25 +28,25 @@ Bibliothèque utilitaire légère (~5 fonctions) écrite en **TypeScript**, qui 
 **Flux d'appel :**
 ```
 getUserMediaStream
-  └── garde inline `!navigator.permissions || !navigator.mediaDevices` (lève NOT_SUPPORTED_ERR)
+  └── garde inline `!navigator.permissions || !navigator.mediaDevices` (lève NotSupportedError)
   └── navigator.permissions.query()         (rejette si 'denied' ; un TypeError de nom non interrogeable est avalé → fallthrough vers acquireMediaStream)
   └── acquireMediaStream()                  (garde `!navigator.mediaDevices` + getUserMedia + Promise.race avec le signal, uniquement si fourni ; réutilisé par les triggers caméra/micro sans re-query)
 
 getPermission
-  └── garde inline `!navigator.permissions` (lève NOT_SUPPORTED_ERR)
+  └── garde inline `!navigator.permissions` (lève NotSupportedError)
   └── navigator.permissions.query()
   └── (sur 'prompt') attend l'événement 'change', borné par signal/timeout
 
 checkPermission
-  └── garde inline `!navigator.permissions` (lève NOT_SUPPORTED_ERR)
+  └── garde inline `!navigator.permissions` (lève NotSupportedError)
   └── navigator.permissions.query()
 ```
 
-- Chaque point d'entrée vérifie **en ligne** l'existence de l'API navigateur (`!navigator.permissions`, plus `!navigator.mediaDevices` pour `getUserMediaStream`) et lève `NOT_SUPPORTED_ERR` si elle est absente. Il n'y a **pas** de helper `is…Supported` exporté : la détection de support côté consommateur passe par `checkPermission` (qui rejette/propage l'erreur de `query()`).
-- `getPermission(permissionName, { signal?, timeout? })` : watcher **passif** qui résout sur `'granted'` une fois la permission accordée. `navigator.permissions.query()` n'affiche **jamais** de dialogue : `'granted'` résout immédiatement, `'denied'` rejette (`NOT_ALLOWED_ERR`). Sur `'prompt'`, attend l'événement `change` (déclenché seulement quand autre chose provoque la vraie requête, ex. `getUserMediaStream`) ; comme rien ne fait transitionner l'état tout seul, l'attente doit être **bornée** par `timeout` (rejette `TimeoutError`) et/ou `signal`. Sans aucune des deux sur `'prompt'`, rejette immédiatement (`InvalidStateError`) au lieu de rester pendante à jamais. Le listener `change` est nettoyé sur tous les chemins de résolution.
+- Chaque point d'entrée vérifie **en ligne** l'existence de l'API navigateur (`!navigator.permissions`, plus `!navigator.mediaDevices` pour `getUserMediaStream`) et lève `NotSupportedError` si elle est absente. Il n'y a **pas** de helper `is…Supported` exporté : la détection de support côté consommateur passe par `checkPermission` (qui rejette/propage l'erreur de `query()`).
+- `getPermission(permissionName, { signal?, timeout? })` : watcher **passif** qui résout sur `'granted'` une fois la permission accordée. `navigator.permissions.query()` n'affiche **jamais** de dialogue : `'granted'` résout immédiatement, `'denied'` rejette (`NotAllowedError`). Sur `'prompt'`, attend l'événement `change` (déclenché seulement quand autre chose provoque la vraie requête, ex. `getUserMediaStream`) ; comme rien ne fait transitionner l'état tout seul, l'attente doit être **bornée** par `timeout` (rejette `TimeoutError`) et/ou `signal`. Sans aucune des deux sur `'prompt'`, rejette immédiatement (`InvalidStateError`) au lieu de rester pendante à jamais. Le listener `change` est nettoyé sur tous les chemins de résolution.
 - `checkPermission(permissionName)` : retourne une Promise résolue immédiatement avec l'état courant de la permission (`'granted'` / `'denied'` / `'prompt'`), sans attendre d'interaction utilisateur ni rejeter sur `'denied'`. Passe par la même garde inline `!navigator.permissions` que `getPermission`. Utile pour lire l'état en amont (bannière, bouton désactivé, branchement UI).
 - `getUserMediaStream(permissionName, mediaStreamConstraints, { signal? })` : appelle directement `navigator.permissions.query()` (rejette si `'denied'`) puis délègue à `acquireMediaStream` — le cœur `getUserMedia()` (c'est `getUserMedia` qui déclenche le vrai dialogue). N'appelle **pas** `getPermission` et n'est donc pas concerné par le contrat d'attente bornée ; l'`AbortSignal` n'est géré via `Promise.race` que lorsqu'un `signal` est fourni, sinon la promesse de `getUserMedia` est renvoyée directement. Le `query()` est enveloppé dans un `try/catch` : un `TypeError` (nom de permission non interrogeable, ex. Firefox/Safari pour `camera`/`microphone`/`midi`) est avalé et le flux retombe sur l'API native ; toute autre erreur se propage. Le chemin actif `_acquirePermission` (getters caméra/micro/midi…) applique le même fallthrough, en traitant le `TypeError` comme `'prompt'` pour déclencher le trigger.
-- `acquireMediaStream(mediaStreamConstraints, signal?)` : helper interne extrait de `getUserMediaStream` — garde `!navigator.mediaDevices` (`NOT_SUPPORTED_ERR`), `getUserMedia()`, et le teardown de la stream sur abort (`Promise.race` + arrêt des tracks d'une stream qui résout après l'abort). Réutilisé tel quel par `cameraTrigger`/`microphoneTrigger`, qui l'appellent **sans** repasser par la `query()` de `getUserMediaStream` puisque `_acquirePermission` a déjà interrogé l'état : **une seule `query()` par acquisition** côté getters caméra/micro.
+- `acquireMediaStream(mediaStreamConstraints, signal?)` : helper interne extrait de `getUserMediaStream` — garde `!navigator.mediaDevices` (`NotSupportedError`), `getUserMedia()`, et le teardown de la stream sur abort (`Promise.race` + arrêt des tracks d'une stream qui résout après l'abort). Réutilisé tel quel par `cameraTrigger`/`microphoneTrigger`, qui l'appellent **sans** repasser par la `query()` de `getUserMediaStream` puisque `_acquirePermission` a déjà interrogé l'état : **une seule `query()` par acquisition** côté getters caméra/micro.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import {
 
 `getPermission`:
 
-Watches a permission and resolves with `'granted'` once it is granted. It is a **passive** watcher built on `navigator.permissions.query()`, so **it never displays a permission dialog**: an already-`'granted'` state resolves right away, while a `'denied'` state rejects with a `NOT_ALLOWED_ERR` `DOMException`.
+Watches a permission and resolves with `'granted'` once it is granted. It is a **passive** watcher built on `navigator.permissions.query()`, so **it never displays a permission dialog**: an already-`'granted'` state resolves right away, while a `'denied'` state rejects with a `NotAllowedError` `DOMException`.
 
 When the state is `'prompt'`, `getPermission` waits for the `change` event — which only fires once _something else_ triggers the real request (e.g. `getUserMediaStream`, `geolocation.getCurrentPosition`) and the user responds. Since nothing transitions a `'prompt'` state on its own, **the wait must be bounded**: pass a `timeout` (rejects with a `TimeoutError` once elapsed), a `signal`, or both. If you provide neither while the state is `'prompt'`, the promise rejects immediately with an `InvalidStateError` instead of hanging forever.
 
@@ -246,7 +246,7 @@ const init = async () => {
 controller.abort()
 ```
 
-> **Feature detection:** there are no `is…Supported` helpers. Every function throws a `NOT_SUPPORTED_ERR` `DOMException` when the API it relies on is unavailable — the Permissions API (all functions), MediaDevices (`getUserMediaStream`), and, for the active getters, the native API they use to surface the prompt (e.g. `getMidiPermission` when `navigator.requestMIDIAccess` is missing). That last case is normalized too, so a missing trigger API never leaks a raw `TypeError`. To probe support upfront, call `checkPermission(name)` and catch — it rejects when the Permissions API is unsupported and propagates `navigator.permissions.query()` errors (e.g. an unrecognized permission name).
+> **Feature detection:** there are no `is…Supported` helpers. Every function throws a `NotSupportedError` `DOMException` when the API it relies on is unavailable — the Permissions API (all functions), MediaDevices (`getUserMediaStream`), and, for the active getters, the native API they use to surface the prompt (e.g. `getMidiPermission` when `navigator.requestMIDIAccess` is missing). That last case is normalized too, so a missing trigger API never leaks a raw `TypeError`. To probe support upfront, call `checkPermission(name)` and catch — it rejects when the Permissions API is unsupported and propagates `navigator.permissions.query()` errors (e.g. an unrecognized permission name).
 
 ## Development
 

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -70,10 +70,9 @@ const APIS: ApiSupport[] = [
 ]
 
 // Friendly copy for the DOMException names the flow can surface, so logs read in plain language
-// instead of raw codes like "NOT_ALLOWED_ERR".
+// instead of raw names like "NotSupportedError".
 const FRIENDLY_ERRORS: Record<string, string> = {
 	NotSupportedError: 'not supported in this browser',
-	NOT_SUPPORTED_ERR: 'not supported in this browser',
 	SecurityError: 'blocked by the browser',
 	TypeError: 'not queryable in this browser',
 }
@@ -192,7 +191,6 @@ async function handleGetPermission(entry: PermissionEntry): Promise<void> {
 function errorToOutcome(err: DOMException): Outcome {
 	switch (err.name) {
 		case 'NotAllowedError':
-		case 'NOT_ALLOWED_ERR':
 			return { kind: 'denied' }
 		case 'TimeoutError':
 			return { kind: 'timeout' }

--- a/src/__tests__/_acquireMediaStream.test.ts
+++ b/src/__tests__/_acquireMediaStream.test.ts
@@ -14,10 +14,10 @@ describe('acquireMediaStream', () => {
 		beforeAll(() => setNavigatorApiUnsupported('mediaDevices'))
 		afterAll(() => restoreNavigatorApi('mediaDevices'))
 
-		it('rejects with NOT_SUPPORTED_ERR', async () => {
+		it('rejects with NotSupportedError', async () => {
 			await expect(acquireMediaStream({ audio: true })).rejects.toMatchObject({
 				message: 'Navigator API: mediaDevices not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 		})
 	})
@@ -139,7 +139,7 @@ describe('acquireMediaStream', () => {
 					// consumes `mediaPromise`'s rejection, so this specifically guards the teardown's own
 					// `catch` sink: without it, `await mediaPromise` would rethrow and leak an unhandled
 					// rejection.
-					rejectStream(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+					rejectStream(new DOMException('Permission denied', 'NotAllowedError'))
 					await new Promise<void>((resolve) => setTimeout(resolve, 0))
 
 					expect(onUnhandled).not.toHaveBeenCalled()

--- a/src/__tests__/_acquirePermission.test.ts
+++ b/src/__tests__/_acquirePermission.test.ts
@@ -19,11 +19,11 @@ describe('acquirePermission', () => {
 		beforeAll(() => setNavigatorApiUnsupported('permissions'))
 		afterAll(() => restoreNavigatorApi('permissions'))
 
-		it('rejects with NOT_SUPPORTED_ERR without firing the trigger', async () => {
+		it('rejects with NotSupportedError without firing the trigger', async () => {
 			const trigger = vi.fn()
 			await expect(acquirePermission('camera', trigger)).rejects.toMatchObject({
 				message: 'Navigator API: permissions not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 			expect(trigger).not.toHaveBeenCalled()
 		})
@@ -45,13 +45,13 @@ describe('acquirePermission', () => {
 			expect(trigger).not.toHaveBeenCalled()
 		})
 
-		it('rejects with NOT_ALLOWED_ERR without firing the trigger when already denied', async () => {
+		it('rejects with NotAllowedError without firing the trigger when already denied', async () => {
 			mockPermissionsQuery.mockResolvedValueOnce(statusOf('denied'))
 			const trigger = vi.fn()
 
 			await expect(acquirePermission('camera', trigger)).rejects.toMatchObject({
 				message: 'Permission denied',
-				name: 'NOT_ALLOWED_ERR',
+				name: 'NotAllowedError',
 			})
 			expect(trigger).not.toHaveBeenCalled()
 		})
@@ -68,10 +68,10 @@ describe('acquirePermission', () => {
 
 		it('rejects with the trigger error on "prompt" when it rejects', async () => {
 			mockPermissionsQuery.mockResolvedValueOnce(statusOf('prompt'))
-			const trigger = vi.fn().mockRejectedValueOnce(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+			const trigger = vi.fn().mockRejectedValueOnce(new DOMException('Permission denied', 'NotAllowedError'))
 
 			await expect(acquirePermission('geolocation', trigger)).rejects.toMatchObject({
-				name: 'NOT_ALLOWED_ERR',
+				name: 'NotAllowedError',
 			})
 		})
 

--- a/src/__tests__/_boundedWait.test.ts
+++ b/src/__tests__/_boundedWait.test.ts
@@ -30,7 +30,7 @@ describe('boundedWait', () => {
 		})
 
 		it('rejects with the producer reason', async () => {
-			const reason = new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+			const reason = new DOMException('Permission denied', 'NotAllowedError')
 			const promise = boundedWait<string>({}, ({ reject }) => {
 				Promise.resolve().then(() => reject(reason))
 				return () => {}

--- a/src/__tests__/_triggers.test.ts
+++ b/src/__tests__/_triggers.test.ts
@@ -62,9 +62,9 @@ describe('permission triggers', () => {
 		})
 
 		it('propagates an acquireMediaStream rejection (denial)', async () => {
-			mockAcquireMediaStream.mockRejectedValueOnce(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+			mockAcquireMediaStream.mockRejectedValueOnce(new DOMException('Permission denied', 'NotAllowedError'))
 
-			await expect(cameraTrigger()).rejects.toMatchObject({ name: 'NOT_ALLOWED_ERR' })
+			await expect(cameraTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 	})
 
@@ -77,13 +77,13 @@ describe('permission triggers', () => {
 			await expect(geolocationTrigger()).resolves.toBeUndefined()
 		})
 
-		it('rejects with NOT_ALLOWED_ERR when permission is denied', async () => {
+		it('rejects with NotAllowedError when permission is denied', async () => {
 			stub(navigator, 'geolocation', {
 				getCurrentPosition: (_success: PositionCallback, error: PositionErrorCallback) =>
 					error({ code: 1, PERMISSION_DENIED: 1 } as GeolocationPositionError),
 			})
 
-			await expect(geolocationTrigger()).rejects.toMatchObject({ name: 'NOT_ALLOWED_ERR' })
+			await expect(geolocationTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 
 		it('propagates other geolocation failures (position unavailable)', async () => {
@@ -95,10 +95,10 @@ describe('permission triggers', () => {
 			await expect(geolocationTrigger()).rejects.toBe(positionError)
 		})
 
-		it('rejects with NOT_SUPPORTED_ERR when the Geolocation API is absent', async () => {
+		it('rejects with NotSupportedError when the Geolocation API is absent', async () => {
 			stub(navigator, 'geolocation', undefined)
 
-			await expect(geolocationTrigger()).rejects.toMatchObject({ name: 'NOT_SUPPORTED_ERR' })
+			await expect(geolocationTrigger()).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 	})
 
@@ -109,16 +109,16 @@ describe('permission triggers', () => {
 			await expect(notificationsTrigger()).resolves.toBeUndefined()
 		})
 
-		it('rejects with NOT_ALLOWED_ERR when permission is not granted', async () => {
+		it('rejects with NotAllowedError when permission is not granted', async () => {
 			stub(globalThis, 'Notification', { requestPermission: () => Promise.resolve('denied') })
 
-			await expect(notificationsTrigger()).rejects.toMatchObject({ name: 'NOT_ALLOWED_ERR' })
+			await expect(notificationsTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 
-		it('rejects with NOT_SUPPORTED_ERR when the Notification API is absent', async () => {
+		it('rejects with NotSupportedError when the Notification API is absent', async () => {
 			stub(globalThis, 'Notification', undefined)
 
-			await expect(notificationsTrigger()).rejects.toMatchObject({ name: 'NOT_SUPPORTED_ERR' })
+			await expect(notificationsTrigger()).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 	})
 
@@ -137,10 +137,10 @@ describe('permission triggers', () => {
 			await expect(midiTrigger()).rejects.toMatchObject({ name: 'SecurityError' })
 		})
 
-		it('rejects with NOT_SUPPORTED_ERR when the Web MIDI API is absent', async () => {
+		it('rejects with NotSupportedError when the Web MIDI API is absent', async () => {
 			stub(navigator, 'requestMIDIAccess', undefined)
 
-			await expect(midiTrigger()).rejects.toMatchObject({ name: 'NOT_SUPPORTED_ERR' })
+			await expect(midiTrigger()).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 	})
 
@@ -151,16 +151,16 @@ describe('permission triggers', () => {
 			await expect(persistentStorageTrigger()).resolves.toBeUndefined()
 		})
 
-		it('rejects with NOT_ALLOWED_ERR when persistence is refused', async () => {
+		it('rejects with NotAllowedError when persistence is refused', async () => {
 			stub(navigator, 'storage', { persist: () => Promise.resolve(false) })
 
-			await expect(persistentStorageTrigger()).rejects.toMatchObject({ name: 'NOT_ALLOWED_ERR' })
+			await expect(persistentStorageTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 
-		it('rejects with NOT_SUPPORTED_ERR when the StorageManager API is absent', async () => {
+		it('rejects with NotSupportedError when the StorageManager API is absent', async () => {
 			stub(navigator, 'storage', undefined)
 
-			await expect(persistentStorageTrigger()).rejects.toMatchObject({ name: 'NOT_SUPPORTED_ERR' })
+			await expect(persistentStorageTrigger()).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 	})
 
@@ -183,10 +183,10 @@ describe('permission triggers', () => {
 			await expect(screenWakeLockTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 
-		it('rejects with NOT_SUPPORTED_ERR when the Screen Wake Lock API is absent', async () => {
+		it('rejects with NotSupportedError when the Screen Wake Lock API is absent', async () => {
 			stub(navigator, 'wakeLock', undefined)
 
-			await expect(screenWakeLockTrigger()).rejects.toMatchObject({ name: 'NOT_SUPPORTED_ERR' })
+			await expect(screenWakeLockTrigger()).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 	})
 
@@ -203,10 +203,10 @@ describe('permission triggers', () => {
 			await expect(storageAccessTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 
-		it('rejects with NOT_SUPPORTED_ERR when the Storage Access API is absent', async () => {
+		it('rejects with NotSupportedError when the Storage Access API is absent', async () => {
 			stub(document, 'requestStorageAccess', undefined)
 
-			await expect(storageAccessTrigger()).rejects.toMatchObject({ name: 'NOT_SUPPORTED_ERR' })
+			await expect(storageAccessTrigger()).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 	})
 })

--- a/src/__tests__/checkPermission.test.ts
+++ b/src/__tests__/checkPermission.test.ts
@@ -15,7 +15,7 @@ describe('checkPermission', () => {
 		it('rejects promise', async () => {
 			await expect(checkPermission('microphone')).rejects.toMatchObject({
 				message: 'Navigator API: permissions not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 		})
 	})

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -16,7 +16,7 @@ describe('getPermission', () => {
 		it('rejects promise', async () => {
 			await expect(getPermission('microphone')).rejects.toMatchObject({
 				message: 'Navigator API: permissions not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 		})
 	})
@@ -34,7 +34,7 @@ describe('getPermission', () => {
 			mockPermissionsQuery.mockResolvedValueOnce(status)
 			await expect(getPermission('microphone')).rejects.toMatchObject({
 				message: 'Permission denied',
-				name: 'NOT_ALLOWED_ERR',
+				name: 'NotAllowedError',
 			})
 		})
 
@@ -53,7 +53,7 @@ describe('getPermission', () => {
 			const promise = getPermission('microphone', { timeout: 1000 })
 			const expectation = expect(promise).rejects.toMatchObject({
 				message: 'Permission denied',
-				name: 'NOT_ALLOWED_ERR',
+				name: 'NotAllowedError',
 			})
 			await flushMicrotasks()
 			status.state = 'denied'

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -27,7 +27,7 @@ describe('getUserMediaStream', () => {
 		it('rejects promise', async () => {
 			await expect(getUserMediaStream('microphone', { audio: true })).rejects.toMatchObject({
 				message: 'Navigator API: permissions or Navigator API: mediaDevices not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 		})
 	})
@@ -49,7 +49,7 @@ describe('getUserMediaStream', () => {
 			it('rejects promise', async () => {
 				await expect(getUserMediaStream('microphone', { audio: true })).rejects.toMatchObject({
 					message: 'Navigator API: permissions or Navigator API: mediaDevices not supported',
-					name: 'NOT_SUPPORTED_ERR',
+					name: 'NotSupportedError',
 				})
 			})
 		})
@@ -67,7 +67,7 @@ describe('getUserMediaStream', () => {
 
 				await expect(getUserMediaStream('microphone', { audio: true })).rejects.toMatchObject({
 					message: 'Permission denied',
-					name: 'NOT_ALLOWED_ERR',
+					name: 'NotAllowedError',
 				})
 				// A prior denial short-circuits before any stream acquisition.
 				expect(mockAcquireMediaStream).not.toHaveBeenCalled()
@@ -97,10 +97,10 @@ describe('getUserMediaStream', () => {
 				const status = new PermissionStatus() as unknown as MockPermissionStatus
 				status.state = 'prompt'
 				mockPermissionsQuery.mockResolvedValueOnce(status)
-				mockAcquireMediaStream.mockRejectedValueOnce(new DOMException('Permission denied', 'NOT_ALLOWED_ERR'))
+				mockAcquireMediaStream.mockRejectedValueOnce(new DOMException('Permission denied', 'NotAllowedError'))
 
 				await expect(getUserMediaStream('microphone', { audio: true })).rejects.toMatchObject({
-					name: 'NOT_ALLOWED_ERR',
+					name: 'NotAllowedError',
 				})
 			})
 
@@ -170,7 +170,7 @@ describe('getUserMediaStream', () => {
 					expect(mockAcquireMediaStream).not.toHaveBeenCalled()
 				})
 
-				it("gives the abort precedence over a 'denied' state (AbortError, not NOT_ALLOWED_ERR)", async () => {
+				it("gives the abort precedence over a 'denied' state (AbortError, not NotAllowedError)", async () => {
 					const controller = new AbortController()
 					const status = new PermissionStatus() as unknown as MockPermissionStatus
 					status.state = 'denied'

--- a/src/__tests__/permissionGetters.test.ts
+++ b/src/__tests__/permissionGetters.test.ts
@@ -50,10 +50,10 @@ describe('dedicated permission getters', () => {
 		beforeAll(() => setNavigatorApiUnsupported('permissions'))
 		afterAll(() => restoreNavigatorApi('permissions'))
 
-		it.each(getters)('$label rejects with NOT_SUPPORTED_ERR', async ({ getter }) => {
+		it.each(getters)('$label rejects with NotSupportedError', async ({ getter }) => {
 			await expect(getter()).rejects.toMatchObject({
 				message: 'Navigator API: permissions not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 		})
 	})

--- a/src/__tests__/watchPermission.test.ts
+++ b/src/__tests__/watchPermission.test.ts
@@ -15,7 +15,7 @@ describe('watchPermission', () => {
 		it('rejects promise', async () => {
 			await expect(watchPermission('microphone', vi.fn())).rejects.toMatchObject({
 				message: 'Navigator API: permissions not supported',
-				name: 'NOT_SUPPORTED_ERR',
+				name: 'NotSupportedError',
 			})
 		})
 	})

--- a/src/_acquireMediaStream.ts
+++ b/src/_acquireMediaStream.ts
@@ -9,14 +9,14 @@
  *
  * @param mediaStreamConstraints    Constraints object. @see https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
  * @param signal                    Optional AbortSignal to cancel the acquisition
- * @throws {DOMException} `NOT_SUPPORTED_ERR` when `navigator.mediaDevices` is unavailable
+ * @throws {DOMException} `NotSupportedError` when `navigator.mediaDevices` is unavailable
  */
 const acquireMediaStream = async (
 	mediaStreamConstraints: MediaStreamConstraints,
 	signal?: AbortSignal
 ): Promise<MediaStream> => {
 	if (!navigator.mediaDevices) {
-		throw new DOMException('Navigator API: mediaDevices not supported', 'NOT_SUPPORTED_ERR')
+		throw new DOMException('Navigator API: mediaDevices not supported', 'NotSupportedError')
 	}
 
 	signal?.throwIfAborted()

--- a/src/_acquirePermission.ts
+++ b/src/_acquirePermission.ts
@@ -2,8 +2,8 @@ import boundedWait from './_boundedWait'
 import type { GetPermissionOptions } from './getPermission'
 
 // A native call that surfaces a permission's real dialog. It must resolve **only** once the
-// permission is granted and reject with a `DOMException` otherwise (`NOT_ALLOWED_ERR` on
-// denial/dismissal, `NOT_SUPPORTED_ERR` when its native API is absent), so `acquirePermission` can
+// permission is granted and reject with a `DOMException` otherwise (`NotAllowedError` on
+// denial/dismissal, `NotSupportedError` when its native API is absent), so `acquirePermission` can
 // treat every permission identically.
 export type PermissionTrigger = (signal?: AbortSignal) => Promise<unknown>
 
@@ -22,7 +22,7 @@ export type PermissionTrigger = (signal?: AbortSignal) => Promise<unknown>
  * @param options.signal    Optional AbortSignal to cancel the pending acquisition
  * @param options.timeout   Optional timeout in milliseconds; rejects with a `TimeoutError`
  * @returns A promise resolved with `'granted'`
- * @throws {DOMException} `NOT_SUPPORTED_ERR`, `NOT_ALLOWED_ERR` (denied) or `TimeoutError`
+ * @throws {DOMException} `NotSupportedError`, `NotAllowedError` (denied) or `TimeoutError`
  */
 const acquirePermission = async (
 	permissionName: PermissionName,
@@ -30,7 +30,7 @@ const acquirePermission = async (
 	{ signal, timeout }: GetPermissionOptions = {}
 ): Promise<'granted'> => {
 	if (!navigator.permissions) {
-		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+		throw new DOMException('Navigator API: permissions not supported', 'NotSupportedError')
 	}
 
 	signal?.throwIfAborted()
@@ -53,7 +53,7 @@ const acquirePermission = async (
 		return 'granted'
 	}
 	if (state === 'denied') {
-		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+		throw new DOMException('Permission denied', 'NotAllowedError')
 	}
 
 	// 'prompt' → fire the trigger to surface the real dialog, bounded by the merged signal/timeout.

--- a/src/_triggers.ts
+++ b/src/_triggers.ts
@@ -1,19 +1,19 @@
 import acquireMediaStream from './_acquireMediaStream'
 import type { PermissionTrigger } from './_acquirePermission'
 
-const permissionDenied = (): DOMException => new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+const permissionDenied = (): DOMException => new DOMException('Permission denied', 'NotAllowedError')
 
 // A permission can be queryable while the API that surfaces its prompt is absent (old browsers,
-// non-secure contexts, workers); normalise that to `NOT_SUPPORTED_ERR` rather than leak a raw
+// non-secure contexts, workers); normalise that to `NotSupportedError` rather than leak a raw
 // `TypeError` from `undefined.someMethod()`.
-const notSupported = (api: string): DOMException => new DOMException(`${api} not supported`, 'NOT_SUPPORTED_ERR')
+const notSupported = (api: string): DOMException => new DOMException(`${api} not supported`, 'NotSupportedError')
 
 const stopTracks = (stream: MediaStream): void => {
 	stream.getTracks().forEach((track) => track.stop())
 }
 
 // Native calls that surface each permission's dialog, normalised to resolve only on grant and reject
-// with a `DOMException` (`NOT_ALLOWED_ERR` denied, `NOT_SUPPORTED_ERR` absent) so `acquirePermission`
+// with a `DOMException` (`NotAllowedError` denied, `NotSupportedError` absent) so `acquirePermission`
 // treats them identically. camera/microphone delegate to `acquireMediaStream` (the `getUserMedia` core
 // of `getUserMediaStream`, minus the permission query `acquirePermission` has already performed).
 

--- a/src/checkPermission.ts
+++ b/src/checkPermission.ts
@@ -5,7 +5,7 @@
  */
 const checkPermission = async (permissionName: PermissionName): Promise<PermissionState> => {
 	if (!navigator.permissions) {
-		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+		throw new DOMException('Navigator API: permissions not supported', 'NotSupportedError')
 	}
 
 	const { state } = await navigator.permissions.query({ name: permissionName })

--- a/src/getPermission.ts
+++ b/src/getPermission.ts
@@ -21,14 +21,14 @@ export const asPermissionName = (name: string): PermissionName => name as Permis
  * @param options.signal    Optional AbortSignal to cancel the pending wait
  * @param options.timeout   Optional timeout in milliseconds; rejects with a `TimeoutError`
  * @returns A promise resolved with `'granted'`
- * @throws {DOMException} `NOT_SUPPORTED_ERR`, `NOT_ALLOWED_ERR` (denied), `InvalidStateError` or `TimeoutError`
+ * @throws {DOMException} `NotSupportedError`, `NotAllowedError` (denied), `InvalidStateError` or `TimeoutError`
  */
 const getPermission = async (
 	permissionName: PermissionName,
 	{ signal, timeout }: GetPermissionOptions = {}
 ): Promise<'granted'> => {
 	if (!navigator.permissions) {
-		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+		throw new DOMException('Navigator API: permissions not supported', 'NotSupportedError')
 	}
 
 	signal?.throwIfAborted()
@@ -72,7 +72,7 @@ const getPermission = async (
 // narrows `state` to `'granted'`, so the return needs no cast.
 const resolveOrRejectBasedOnState = (state: Exclude<PermissionState, 'prompt'>): 'granted' => {
 	if (state === 'denied') {
-		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+		throw new DOMException('Permission denied', 'NotAllowedError')
 	}
 	return state
 }

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -19,7 +19,7 @@ const getUserMediaStream = async (
 	if (!navigator.permissions || !navigator.mediaDevices) {
 		throw new DOMException(
 			'Navigator API: permissions or Navigator API: mediaDevices not supported',
-			'NOT_SUPPORTED_ERR'
+			'NotSupportedError'
 		)
 	}
 
@@ -41,7 +41,7 @@ const getUserMediaStream = async (
 	signal?.throwIfAborted()
 
 	if (denied) {
-		throw new DOMException('Permission denied', 'NOT_ALLOWED_ERR')
+		throw new DOMException('Permission denied', 'NotAllowedError')
 	}
 
 	// The `getUserMedia` call (and its abort teardown) lives in `acquireMediaStream`, which the

--- a/src/watchPermission.ts
+++ b/src/watchPermission.ts
@@ -31,7 +31,7 @@ export interface WatchPermissionOptions {
  * @param options.signal            Optional AbortSignal that stops the subscription (removes the `change` listener); aborting before the subscription is active rejects with `AbortError` instead
  * @param options.emitImmediately   When `true` (default), invokes `onChange` with the current state before listening for changes
  * @returns A promise resolved once the subscription is active
- * @throws {DOMException} `NOT_SUPPORTED_ERR` when the Permissions API is unavailable, or `AbortError` when `signal` is already aborted before the subscription is active
+ * @throws {DOMException} `NotSupportedError` when the Permissions API is unavailable, or `AbortError` when `signal` is already aborted before the subscription is active
  */
 const watchPermission = async (
 	permissionName: PermissionName,
@@ -39,7 +39,7 @@ const watchPermission = async (
 	{ signal, emitImmediately = true }: WatchPermissionOptions = {}
 ): Promise<void> => {
 	if (!navigator.permissions) {
-		throw new DOMException('Navigator API: permissions not supported', 'NOT_SUPPORTED_ERR')
+		throw new DOMException('Navigator API: permissions not supported', 'NotSupportedError')
 	}
 
 	signal?.throwIfAborted()


### PR DESCRIPTION
## Summary

The library surfaced a single logical failure under two different `error.name` values: the non-standard legacy-style `NOT_ALLOWED_ERR` / `NOT_SUPPORTED_ERR` thrown by the library itself, versus the standard `NotAllowedError` / `NotSupportedError` that leaked through from native browser APIs (`getUserMedia`, screen wake lock, storage access). This PR makes every library-thrown `DOMException` use the web-standard name, so denial → `NotAllowedError` and unsupported → `NotSupportedError` everywhere — matching the already-standard `AbortError` / `TimeoutError` / `InvalidStateError`.

## Changes

- **Library** — replaced `NOT_ALLOWED_ERR` → `NotAllowedError` and `NOT_SUPPORTED_ERR` → `NotSupportedError` in `getPermission`, `checkPermission`, `getUserMediaStream`, `_acquirePermission`, `_acquireMediaStream`, `_triggers` and `watchPermission` (messages unchanged; only the `DOMException` name changes). JSDoc/`@throws` and inline comments updated to match.
- **Tests** — updated every `name:` assertion and `DOMException` fixture across the suite to the standardized names (no behavioural change; 140 tests still green at 100% coverage).
- **Demo** — dropped the now-dead legacy aliases in `demo/main.ts`: the `case 'NOT_ALLOWED_ERR'` branch (the dual-name handling the issue cites as direct evidence) and the `NOT_SUPPORTED_ERR` entry in `FRIENDLY_ERRORS`.
- **Docs** — aligned `README.md` and `CLAUDE.md` error-contract references with the standardized names. `CHANGELOG.md` left untouched (historical release notes).

## ⚠️ Breaking changes

- **Error names**: errors previously thrown with `error.name === 'NOT_ALLOWED_ERR'` are now `'NotAllowedError'`, and `'NOT_SUPPORTED_ERR'` is now `'NotSupportedError'`.
- **Migration**: consumers branching on `error.name` must match the standard names (`'NotAllowedError'` / `'NotSupportedError'`) instead of the legacy ones. Code already following the web-standard convention now works against the library's own errors too — and `getUserMediaStream` no longer reports denial under two different names depending on whether the `query()` or the prompt rejected.

The commit carries a `BREAKING CHANGE:` footer; the 2.0 beta is the intended window to land this before the stable release.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn test:ci` — 140 tests pass, 100% coverage
- [x] `yarn build`
- [x] `yarn lint`
- [x] `yarn format:check`
- [x] Demo bundles cleanly (`vite build demo`)

Closes #159