### PR TITLE
fix(triggers): Standardize geolocation non-denial failures to DOMException

### DIFF
--- a/src/__tests__/_triggers.test.ts
+++ b/src/__tests__/_triggers.test.ts
@@ -86,13 +86,53 @@ describe('permission triggers', () => {
 			await expect(geolocationTrigger()).rejects.toMatchObject({ name: 'NotAllowedError' })
 		})
 
-		it('propagates other geolocation failures (position unavailable)', async () => {
-			const positionError = { code: 2, PERMISSION_DENIED: 1 } as GeolocationPositionError
+		it('wraps POSITION_UNAVAILABLE in a NotReadableError DOMException, preserving the cause', async () => {
+			const positionError = {
+				code: 2,
+				message: 'unavailable',
+				PERMISSION_DENIED: 1,
+				TIMEOUT: 3,
+			} as GeolocationPositionError
 			stub(navigator, 'geolocation', {
 				getCurrentPosition: (_success: PositionCallback, error: PositionErrorCallback) => error(positionError),
 			})
 
-			await expect(geolocationTrigger()).rejects.toBe(positionError)
+			await expect(geolocationTrigger()).rejects.toBeInstanceOf(DOMException)
+			await expect(geolocationTrigger()).rejects.toMatchObject({
+				name: 'NotReadableError',
+				message: 'unavailable',
+				cause: positionError,
+			})
+		})
+
+		it('falls back to a default message when the native error has none', async () => {
+			const positionError = { code: 2, message: '', PERMISSION_DENIED: 1, TIMEOUT: 3 } as GeolocationPositionError
+			stub(navigator, 'geolocation', {
+				getCurrentPosition: (_success: PositionCallback, error: PositionErrorCallback) => error(positionError),
+			})
+
+			await expect(geolocationTrigger()).rejects.toMatchObject({
+				name: 'NotReadableError',
+				message: 'Geolocation unavailable',
+			})
+		})
+
+		it('wraps TIMEOUT in a TimeoutError DOMException, preserving the cause', async () => {
+			const positionError = {
+				code: 3,
+				message: 'timed out',
+				PERMISSION_DENIED: 1,
+				TIMEOUT: 3,
+			} as GeolocationPositionError
+			stub(navigator, 'geolocation', {
+				getCurrentPosition: (_success: PositionCallback, error: PositionErrorCallback) => error(positionError),
+			})
+
+			await expect(geolocationTrigger()).rejects.toMatchObject({
+				name: 'TimeoutError',
+				message: 'timed out',
+				cause: positionError,
+			})
 		})
 
 		it('rejects with NotSupportedError when the Geolocation API is absent', async () => {

--- a/src/_triggers.ts
+++ b/src/_triggers.ts
@@ -8,10 +8,6 @@ const permissionDenied = (): DOMException => new DOMException('Permission denied
 // `TypeError` from `undefined.someMethod()`.
 const notSupported = (api: string): DOMException => new DOMException(`${api} not supported`, 'NotSupportedError')
 
-// `getCurrentPosition`'s non-denial failures surface a `GeolocationPositionError`, which is **not** a
-// `DOMException` and exposes no `name`. Wrap it so the trigger contract holds (`.name`/`.message` always
-// present): `TIMEOUT` → `TimeoutError`, `POSITION_UNAVAILABLE` → `NotReadableError`, keeping the native
-// error as `cause` (so `code`/`message` remain reachable).
 const geolocationFailed = (error: GeolocationPositionError): DOMException =>
 	Object.assign(
 		new DOMException(
@@ -43,8 +39,6 @@ export const geolocationTrigger: PermissionTrigger = () =>
 		}
 		navigator.geolocation.getCurrentPosition(
 			() => resolve(),
-			// PERMISSION_DENIED is a denial (NotAllowedError); POSITION_UNAVAILABLE/TIMEOUT are wrapped
-			// in a DOMException so the trigger always rejects with one, never a raw GeolocationPositionError.
 			(error) => reject(error.code === error.PERMISSION_DENIED ? permissionDenied() : geolocationFailed(error))
 		)
 	})

--- a/src/_triggers.ts
+++ b/src/_triggers.ts
@@ -8,6 +8,19 @@ const permissionDenied = (): DOMException => new DOMException('Permission denied
 // `TypeError` from `undefined.someMethod()`.
 const notSupported = (api: string): DOMException => new DOMException(`${api} not supported`, 'NotSupportedError')
 
+// `getCurrentPosition`'s non-denial failures surface a `GeolocationPositionError`, which is **not** a
+// `DOMException` and exposes no `name`. Wrap it so the trigger contract holds (`.name`/`.message` always
+// present): `TIMEOUT` → `TimeoutError`, `POSITION_UNAVAILABLE` → `NotReadableError`, keeping the native
+// error as `cause` (so `code`/`message` remain reachable).
+const geolocationFailed = (error: GeolocationPositionError): DOMException =>
+	Object.assign(
+		new DOMException(
+			error.message || 'Geolocation unavailable',
+			error.code === error.TIMEOUT ? 'TimeoutError' : 'NotReadableError'
+		),
+		{ cause: error }
+	)
+
 const stopTracks = (stream: MediaStream): void => {
 	stream.getTracks().forEach((track) => track.stop())
 }
@@ -30,8 +43,9 @@ export const geolocationTrigger: PermissionTrigger = () =>
 		}
 		navigator.geolocation.getCurrentPosition(
 			() => resolve(),
-			// Only PERMISSION_DENIED is a denial; POSITION_UNAVAILABLE/TIMEOUT propagate as-is.
-			(error) => reject(error.code === error.PERMISSION_DENIED ? permissionDenied() : error)
+			// PERMISSION_DENIED is a denial (NotAllowedError); POSITION_UNAVAILABLE/TIMEOUT are wrapped
+			// in a DOMException so the trigger always rejects with one, never a raw GeolocationPositionError.
+			(error) => reject(error.code === error.PERMISSION_DENIED ? permissionDenied() : geolocationFailed(error))
 		)
 	})
 


### PR DESCRIPTION
## Summary
`geolocationTrigger` only mapped `PERMISSION_DENIED` to a `DOMException` and re-rejected `POSITION_UNAVAILABLE` / `TIMEOUT` as the raw `GeolocationPositionError`. That type is **not** a `DOMException` and exposes no `name`, so consumers doing `error.name === …` got `undefined` — breaking the trigger's documented "reject = `DOMException`" contract and diverging from every other trigger.

This wraps those non-denial failures in a `DOMException` with a present, meaningful `name`, keeping the original native error as `cause`.

## Changes
- `src/_triggers.ts` — add a `geolocationFailed(error)` helper and route non-denial failures through it:
  - `TIMEOUT` (code 3) → `TimeoutError`
  - `POSITION_UNAVAILABLE` (code 2) → `NotReadableError`
  - native `GeolocationPositionError` preserved as `cause` (so `code` / `message` stay reachable); falls back to a default message when the native error has none.
- `src/__tests__/_triggers.test.ts` — replace the old "propagates the raw error" expectation with coverage for the wrapped `NotReadableError` / `TimeoutError` (name, message, `cause`, `instanceof DOMException`) plus the default-message fallback.

## Test plan
- [x] `yarn test:ci` — 142 passed, 100% coverage
- [x] `yarn build`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn format:check`
- [x] `yarn dev` — demo boots without errors

## ⚠️ Behavior change
Non-denial geolocation failures now reject with a `DOMException` instead of the raw `GeolocationPositionError`. The numeric `code` is no longer on the top-level error but remains available via `error.cause.code`. This is the intended fix (the previous error had no `name` at all, an undocumented shape), so it ships as a `fix`, not a breaking change.

Closes #160