### PR TITLE
feat: Add an optional timeout to getUserMediaStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ controller.abort()
 
 `getUserMediaStream`:
 
-Returns a promise resolved when the permission is granted and the stream is retrieved. Accepts an optional `signal` to cancel the entire operation. If the signal aborts while acquisition is still in flight, a stream that resolves afterwards is torn down automatically (its tracks are stopped), so the camera or microphone is never left active.
+Returns a promise resolved when the permission is granted and the stream is retrieved. Accepts an optional `signal` to cancel the entire operation and an optional `timeout` (in milliseconds) that rejects with a `TimeoutError` once it elapses — the same bounded-wait ergonomics the active getters offer, handy for unattended flows. If the signal aborts or the timeout fires while acquisition is still in flight, a stream that resolves afterwards is torn down automatically (its tracks are stopped), so the camera or microphone is never left active.
 
 The `permissionName` and `mediaStreamConstraints` must match the same media device:
 
@@ -244,6 +244,23 @@ const init = async () => {
 
 // Cancel the operation at any point (permission wait or stream acquisition)
 controller.abort()
+```
+
+To time-box an unattended acquisition without wiring your own `AbortController` and timer, pass a `timeout` (it can be combined with a `signal`):
+
+```javascript
+import { getUserMediaStream } from '@untemps/user-permissions-utils'
+
+const init = async () => {
+    try {
+        // Reject with a `TimeoutError` if the stream isn't acquired within 10s
+        const stream = await getUserMediaStream('camera', { video: true }, { timeout: 10000 })
+        ...
+    } catch (error) {
+        if (error.name === 'TimeoutError') return // no response in time — the camera is never left active
+        console.error(error)
+    }
+}
 ```
 
 > **Feature detection:** there are no `is…Supported` helpers. Every function throws a `NotSupportedError` `DOMException` when the API it relies on is unavailable — the Permissions API (all functions), MediaDevices (`getUserMediaStream`), and, for the active getters, the native API they use to surface the prompt (e.g. `getMidiPermission` when `navigator.requestMIDIAccess` is missing). That last case is normalized too, so a missing trigger API never leaks a raw `TypeError`. To probe support upfront, call `checkPermission(name)` and catch — it rejects when the Permissions API is unsupported and propagates `navigator.permissions.query()` errors (e.g. an unrecognized permission name).

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -3,6 +3,7 @@ vi.mock('../_acquireMediaStream', () => ({ default: vi.fn() }))
 import getUserMediaStream from '../getUserMediaStream'
 import acquireMediaStream from '../_acquireMediaStream'
 import {
+	flushMicrotasks,
 	setNavigatorApiUnsupported,
 	restoreNavigatorApi,
 	setupPermissionsMock,
@@ -14,6 +15,12 @@ import {
 
 const FAKE_STREAM = {} as MediaStream
 const mockAcquireMediaStream = vi.mocked(acquireMediaStream)
+
+const statusOf = (state: PermissionState): MockPermissionStatus => {
+	const status = new PermissionStatus() as unknown as MockPermissionStatus
+	status.state = state
+	return status
+}
 
 // `getUserMediaStream` owns the guard + permission query (denied short-circuit, TypeError
 // fall-through) and then delegates the actual `getUserMedia` call — including the abort teardown — to
@@ -196,6 +203,86 @@ describe('getUserMediaStream', () => {
 						getUserMediaStream('camera', { video: true }, { signal: controller.signal })
 					).resolves.toBe(FAKE_STREAM)
 					expect(mockAcquireMediaStream).toHaveBeenCalledWith({ video: true }, controller.signal)
+				})
+			})
+
+			// A `timeout` is merged with any caller `signal` into one internal AbortSignal (via
+			// `boundedWait`) that is forwarded to `acquireMediaStream`, so a stream resolving after the
+			// deadline is still torn down. The merge/teardown mechanics live in the `_boundedWait` and
+			// `_acquireMediaStream` suites; here we assert `getUserMediaStream` wires the timeout through.
+			describe('timeout', () => {
+				it('forwards a merged signal (not the raw caller signal) to acquireMediaStream', async () => {
+					mockPermissionsQuery.mockResolvedValueOnce(statusOf('granted'))
+					mockAcquireMediaStream.mockResolvedValueOnce(FAKE_STREAM)
+
+					await expect(getUserMediaStream('camera', { video: true }, { timeout: 1000 })).resolves.toBe(
+						FAKE_STREAM
+					)
+					expect(mockAcquireMediaStream.mock.calls[0][0]).toEqual({ video: true })
+					// Not the raw signal (there is none) — a fresh internal signal carrying the timeout.
+					expect(mockAcquireMediaStream.mock.calls[0][1]).toBeInstanceOf(AbortSignal)
+				})
+
+				it('rejects with TimeoutError when the timeout elapses before acquisition settles', async () => {
+					vi.useFakeTimers()
+					try {
+						mockPermissionsQuery.mockResolvedValueOnce(statusOf('prompt'))
+						// Never settles on its own: only the timeout can settle the acquisition.
+						let forwardedSignal: AbortSignal | undefined
+						mockAcquireMediaStream.mockImplementationOnce((_constraints, signal) => {
+							forwardedSignal = signal
+							return new Promise<MediaStream>(() => {})
+						})
+
+						const promise = getUserMediaStream('microphone', { audio: true }, { timeout: 1000 })
+						const expectation = expect(promise).rejects.toMatchObject({ name: 'TimeoutError' })
+						await vi.advanceTimersByTimeAsync(1000)
+						await expectation
+
+						// The timeout aborts the internal signal forwarded to acquireMediaStream so it can
+						// tear down a late stream.
+						expect(forwardedSignal?.aborted).toBe(true)
+					} finally {
+						vi.useRealTimers()
+					}
+				})
+
+				it('clears the timeout when acquisition resolves first', async () => {
+					vi.useFakeTimers()
+					try {
+						mockPermissionsQuery.mockResolvedValueOnce(statusOf('granted'))
+						mockAcquireMediaStream.mockResolvedValueOnce(FAKE_STREAM)
+
+						await expect(getUserMediaStream('camera', { video: true }, { timeout: 1000 })).resolves.toBe(
+							FAKE_STREAM
+						)
+						// No leaked timer left pending.
+						expect(vi.getTimerCount()).toBe(0)
+					} finally {
+						vi.useRealTimers()
+					}
+				})
+
+				it('gives a caller abort precedence over the timeout (AbortError, not TimeoutError)', async () => {
+					const controller = new AbortController()
+					mockPermissionsQuery.mockResolvedValueOnce(statusOf('prompt'))
+					let forwardedSignal: AbortSignal | undefined
+					mockAcquireMediaStream.mockImplementationOnce((_constraints, signal) => {
+						forwardedSignal = signal
+						return new Promise<MediaStream>(() => {})
+					})
+
+					const promise = getUserMediaStream(
+						'microphone',
+						{ audio: true },
+						{ signal: controller.signal, timeout: 10000 }
+					)
+					await flushMicrotasks()
+					controller.abort()
+
+					await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+					// The caller abort also aborts the internal signal so acquireMediaStream can tear down.
+					expect(forwardedSignal?.aborted).toBe(true)
 				})
 			})
 		})

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -206,10 +206,6 @@ describe('getUserMediaStream', () => {
 				})
 			})
 
-			// A `timeout` is merged with any caller `signal` into one internal AbortSignal (via
-			// `boundedWait`) that is forwarded to `acquireMediaStream`, so a stream resolving after the
-			// deadline is still torn down. The merge/teardown mechanics live in the `_boundedWait` and
-			// `_acquireMediaStream` suites; here we assert `getUserMediaStream` wires the timeout through.
 			describe('timeout', () => {
 				it('forwards a merged signal (not the raw caller signal) to acquireMediaStream', async () => {
 					mockPermissionsQuery.mockResolvedValueOnce(statusOf('granted'))
@@ -219,7 +215,6 @@ describe('getUserMediaStream', () => {
 						FAKE_STREAM
 					)
 					expect(mockAcquireMediaStream.mock.calls[0][0]).toEqual({ video: true })
-					// Not the raw signal (there is none) — a fresh internal signal carrying the timeout.
 					expect(mockAcquireMediaStream.mock.calls[0][1]).toBeInstanceOf(AbortSignal)
 				})
 
@@ -227,7 +222,6 @@ describe('getUserMediaStream', () => {
 					vi.useFakeTimers()
 					try {
 						mockPermissionsQuery.mockResolvedValueOnce(statusOf('prompt'))
-						// Never settles on its own: only the timeout can settle the acquisition.
 						let forwardedSignal: AbortSignal | undefined
 						mockAcquireMediaStream.mockImplementationOnce((_constraints, signal) => {
 							forwardedSignal = signal
@@ -239,8 +233,6 @@ describe('getUserMediaStream', () => {
 						await vi.advanceTimersByTimeAsync(1000)
 						await expectation
 
-						// The timeout aborts the internal signal forwarded to acquireMediaStream so it can
-						// tear down a late stream.
 						expect(forwardedSignal?.aborted).toBe(true)
 					} finally {
 						vi.useRealTimers()
@@ -256,7 +248,6 @@ describe('getUserMediaStream', () => {
 						await expect(getUserMediaStream('camera', { video: true }, { timeout: 1000 })).resolves.toBe(
 							FAKE_STREAM
 						)
-						// No leaked timer left pending.
 						expect(vi.getTimerCount()).toBe(0)
 					} finally {
 						vi.useRealTimers()
@@ -281,7 +272,6 @@ describe('getUserMediaStream', () => {
 					controller.abort()
 
 					await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
-					// The caller abort also aborts the internal signal so acquireMediaStream can tear down.
 					expect(forwardedSignal?.aborted).toBe(true)
 				})
 			})

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -49,18 +49,13 @@ const getUserMediaStream = async (
 
 	// The `getUserMedia` call (and its abort teardown) lives in `acquireMediaStream`, which the
 	// camera/microphone triggers reuse directly so the active getters never re-query the permission.
-	// Without a `timeout`, hand it the caller `signal` straight through.
 	if (timeout === undefined) {
 		return acquireMediaStream(mediaStreamConstraints, signal)
 	}
 
-	// With a `timeout`, merge `signal` + a `TimeoutError` timer into one internal signal via the same
-	// `boundedWait` helper the active getters use, and forward it to `acquireMediaStream`. Because that
-	// signal aborts on timeout, a stream resolving after the deadline is still torn down — the
-	// camera/microphone is never left live. Rejects with a `TimeoutError`, consistent with the getters.
 	return boundedWait<MediaStream>({ signal, timeout }, ({ signal: waitSignal, resolve, reject }) => {
 		acquireMediaStream(mediaStreamConstraints, waitSignal).then(resolve, reject)
-		return () => {} // `acquireMediaStream` owns its own teardown; nothing extra to detach here
+		return () => {}
 	})
 }
 

--- a/src/getUserMediaStream.ts
+++ b/src/getUserMediaStream.ts
@@ -1,7 +1,9 @@
 import acquireMediaStream from './_acquireMediaStream'
+import boundedWait from './_boundedWait'
 
 export interface GetUserMediaStreamOptions {
 	signal?: AbortSignal
+	timeout?: number
 }
 
 /**
@@ -10,11 +12,12 @@ export interface GetUserMediaStreamOptions {
  * @param mediaStreamConstraints    Constraints object. @see https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
  * @param options                   Optional settings
  * @param options.signal            Optional AbortSignal to cancel the operation
+ * @param options.timeout           Optional timeout in milliseconds; rejects with a `TimeoutError`
  */
 const getUserMediaStream = async (
 	permissionName: PermissionName,
 	mediaStreamConstraints: MediaStreamConstraints,
-	{ signal }: GetUserMediaStreamOptions = {}
+	{ signal, timeout }: GetUserMediaStreamOptions = {}
 ): Promise<MediaStream> => {
 	if (!navigator.permissions || !navigator.mediaDevices) {
 		throw new DOMException(
@@ -46,7 +49,19 @@ const getUserMediaStream = async (
 
 	// The `getUserMedia` call (and its abort teardown) lives in `acquireMediaStream`, which the
 	// camera/microphone triggers reuse directly so the active getters never re-query the permission.
-	return acquireMediaStream(mediaStreamConstraints, signal)
+	// Without a `timeout`, hand it the caller `signal` straight through.
+	if (timeout === undefined) {
+		return acquireMediaStream(mediaStreamConstraints, signal)
+	}
+
+	// With a `timeout`, merge `signal` + a `TimeoutError` timer into one internal signal via the same
+	// `boundedWait` helper the active getters use, and forward it to `acquireMediaStream`. Because that
+	// signal aborts on timeout, a stream resolving after the deadline is still torn down — the
+	// camera/microphone is never left live. Rejects with a `TimeoutError`, consistent with the getters.
+	return boundedWait<MediaStream>({ signal, timeout }, ({ signal: waitSignal, resolve, reject }) => {
+		acquireMediaStream(mediaStreamConstraints, waitSignal).then(resolve, reject)
+		return () => {} // `acquireMediaStream` owns its own teardown; nothing extra to detach here
+	})
 }
 
 export default getUserMediaStream


### PR DESCRIPTION
## Summary

`getUserMediaStream` accepted only a `signal`, while the active getters (`getCameraPermission`, …) also accept a `timeout`. This adds an optional `timeout` to `getUserMediaStream` so consumers who need the resulting `MediaStream` can time-box acquisition for unattended flows without wiring their own `AbortController` + timer — removing the asymmetry with `getCameraPermission({ timeout })`.

## Changes

- Extend `GetUserMediaStreamOptions` with an optional `timeout?: number`.
- When `timeout` is set, merge the caller `signal` and a `TimeoutError` timer into one internal `AbortSignal` via the existing `boundedWait` helper (the same one the active getters use) and forward it to `acquireMediaStream`. Because that signal aborts on timeout, a stream resolving after the deadline is still torn down (tracks stopped) — the camera/microphone is never left live. On timeout the promise rejects with a `TimeoutError` `DOMException`, consistent with the getters.
- Without a `timeout`, the previous fast path (`acquireMediaStream(constraints, signal)`) is unchanged.
- Add tests covering the merged-signal forwarding, `TimeoutError` rejection + teardown, timer cleanup on resolve, and caller-abort precedence over the timeout.
- Document the new option in the README with a usage example.

## Test plan

- [ ] `yarn typecheck` — passes
- [ ] `yarn test:ci` — 146 tests pass, 100% coverage
- [ ] `yarn build` — passes
- [ ] `yarn lint` — passes
- [ ] `yarn format:check` — passes
- [ ] Demo still builds (`vite build demo`) — unaffected (it uses the dedicated getters, not `getUserMediaStream` directly)

## Breaking changes

None — `timeout` is optional and purely additive.

Closes #162