### PR TITLE
fix: getPushPermission queries push with userVisibleOnly and normalizes the non-queryable TypeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const init = async () => {
 
 > **Pass a `timeout` for unattended flows.** Unlike the passive getters (and `getPermission`), the active getters don't require `signal`/`timeout` on `'prompt'` — the native prompt they surface settles the wait when the user responds. But if the user neither accepts nor dismisses, the wait lasts as long as the prompt does. Add a `timeout` (and/or `signal`) whenever you can't rely on a timely response.
 
-> **Non-queryable permission names fall through to the native API.** Some browsers support a device but reject `navigator.permissions.query()` for its name with a `TypeError` (e.g. Firefox / Safari for `camera`, `microphone`, `midi`). The active getters and `getUserMediaStream` catch that and surface the prompt through the native API anyway (`getUserMedia`, `requestMIDIAccess`, …) instead of failing, so they work cross-browser. The passive getters and `checkPermission` have no native trigger to fall back on, so they still propagate the `query()` error.
+> **Non-queryable permission names fall through to the native API.** Some browsers support a device but reject `navigator.permissions.query()` for its name with a `TypeError` (e.g. Firefox / Safari for `camera`, `microphone`, `midi`). The active getters and `getUserMediaStream` catch that and surface the prompt through the native API anyway (`getUserMedia`, `requestMIDIAccess`, …) instead of failing, so they work cross-browser. The passive getters have no native trigger to fall back on, so they instead **normalize** the `TypeError` to a `NotSupportedError` `DOMException` — keeping the guarantee that every getter rejects with a `DOMException`. Only `checkPermission`, which reports the raw state, still propagates the original `query()` error so callers can inspect it.
 
 **Passive getters** only _watch_ the state (exactly like `getPermission`) and never surface a dialog, because the library cannot trigger them from a permission name alone without consumer-owned infrastructure or a privacy-sensitive side effect. The **bounded-wait** requirement on `'prompt'` therefore applies (pass `signal` and/or `timeout`):
 
@@ -124,6 +124,8 @@ const init = async () => {
 | `getClipboardWritePermission` | `'clipboard-write'` | the only way to prompt is to overwrite the user's clipboard |
 
 Trigger those yourself (e.g. `registration.pushManager.subscribe(...)`, `navigator.clipboard.read()`), then let the passive getter resolve.
+
+> `getPushPermission` queries `push` with `userVisibleOnly: true` because Chromium rejects the descriptor otherwise (silent push is not allowed). On browsers that can't query `push` at all (Firefox / Safari), the resulting `TypeError` is normalized to a `NotSupportedError` `DOMException` like the other passive getters.
 
 > `clipboard-read` and `clipboard-write` are valid permission names at runtime but are not (yet) part of the DOM `PermissionName` type, so those two wrappers assert the name internally.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ const tseslint = require('typescript-eslint')
 const globals = require('globals')
 
 module.exports = tseslint.config(
-	{ ignores: ['dist/**', 'coverage/**'] },
+	{ ignores: ['dist/**', 'demo/dist/**', 'coverage/**'] },
 	js.configs.recommended,
 	...tseslint.configs.recommended,
 	{

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -80,9 +80,6 @@ describe('getPermission', () => {
 			await expect(getPermission('microphone')).rejects.toEqual(new Error('ERR'))
 		})
 
-		// A passive watcher can't fall through to a native trigger (unlike acquirePermission /
-		// getUserMediaStream), so a non-queryable name — or `push` rejected for lacking
-		// `userVisibleOnly` — must surface as a `DOMException`, not the raw `TypeError`.
 		it('normalizes a TypeError from query() to a NotSupportedError DOMException', async () => {
 			mockPermissionsQuery.mockImplementationOnce(() => {
 				throw new TypeError("Failed to read the 'userVisibleOnly' property")
@@ -93,15 +90,12 @@ describe('getPermission', () => {
 			await expect(promise).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 
-		// A non-TypeError must still propagate unchanged — only the non-queryable `TypeError` is normalized.
 		it('propagates a non-TypeError query() rejection unchanged', async () => {
 			const error = new DOMException('boom', 'SecurityError')
 			mockPermissionsQuery.mockRejectedValueOnce(error)
 			await expect(getPermission('microphone')).rejects.toBe(error)
 		})
 
-		// Permissions that need extra descriptor members (e.g. `push` requires `userVisibleOnly: true`
-		// on Chromium) are passed as a full descriptor, which must reach `query()` verbatim.
 		it('forwards a full descriptor (push userVisibleOnly) to query()', async () => {
 			const status = new PermissionStatus() as unknown as MockPermissionStatus
 			status.state = 'granted'

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -80,6 +80,37 @@ describe('getPermission', () => {
 			await expect(getPermission('microphone')).rejects.toEqual(new Error('ERR'))
 		})
 
+		// A passive watcher can't fall through to a native trigger (unlike acquirePermission /
+		// getUserMediaStream), so a non-queryable name — or `push` rejected for lacking
+		// `userVisibleOnly` — must surface as a `DOMException`, not the raw `TypeError`.
+		it('normalizes a TypeError from query() to a NotSupportedError DOMException', async () => {
+			mockPermissionsQuery.mockImplementationOnce(() => {
+				throw new TypeError("Failed to read the 'userVisibleOnly' property")
+			})
+
+			const promise = getPermission('push')
+			await expect(promise).rejects.toBeInstanceOf(DOMException)
+			await expect(promise).rejects.toMatchObject({ name: 'NotSupportedError' })
+		})
+
+		// A non-TypeError must still propagate unchanged — only the non-queryable `TypeError` is normalized.
+		it('propagates a non-TypeError query() rejection unchanged', async () => {
+			const error = new DOMException('boom', 'SecurityError')
+			mockPermissionsQuery.mockRejectedValueOnce(error)
+			await expect(getPermission('microphone')).rejects.toBe(error)
+		})
+
+		// Permissions that need extra descriptor members (e.g. `push` requires `userVisibleOnly: true`
+		// on Chromium) are passed as a full descriptor, which must reach `query()` verbatim.
+		it('forwards a full descriptor (push userVisibleOnly) to query()', async () => {
+			const status = new PermissionStatus() as unknown as MockPermissionStatus
+			status.state = 'granted'
+			mockPermissionsQuery.mockResolvedValueOnce(status)
+
+			await expect(getPermission({ name: 'push', userVisibleOnly: true })).resolves.toBe('granted')
+			expect(mockPermissionsQuery).toHaveBeenCalledWith({ name: 'push', userVisibleOnly: true })
+		})
+
 		describe('bounded wait (prompt state)', () => {
 			it('rejects immediately when state is prompt and neither signal nor timeout is provided', async () => {
 				const status = new PermissionStatus() as unknown as MockPermissionStatus

--- a/src/__tests__/permissionGetters.test.ts
+++ b/src/__tests__/permissionGetters.test.ts
@@ -26,9 +26,6 @@ type PermissionGetter = (options?: GetPermissionOptions) => Promise<'granted'>
 // suite drives every getter through the contract they all share — guard, `'granted'` short-circuit
 // and options forwarding — leaving the active trigger/acquire mechanics to `_acquirePermission` and
 // `_triggers` tests. The `passive` flag marks the three getters that intentionally never prompt.
-// `descriptor` is the exact object the getter is expected to pass to `navigator.permissions.query()`;
-// it defaults to `{ name }` and is only spelled out for getters that add extra descriptor members
-// (e.g. `getPushPermission` must query with `userVisibleOnly: true`).
 const getters: ReadonlyArray<{
 	label: string
 	getter: PermissionGetter
@@ -91,9 +88,6 @@ describe('dedicated permission getters', () => {
 			expect(mockPermissionsQuery).toHaveBeenCalledWith(descriptor ?? { name })
 		})
 
-		// End-to-end guard for the push bug (#167): `query({ name: 'push' })` throws a `TypeError` on
-		// browsers that can't query the name (Firefox/Safari) — the passive getter must surface a
-		// `NotSupportedError` `DOMException`, never the raw `TypeError`.
 		it('getPushPermission normalizes a query() TypeError to a NotSupportedError DOMException', async () => {
 			mockPermissionsQuery.mockImplementationOnce(() => {
 				throw new TypeError("'push' is not a valid enum value of type PermissionName")

--- a/src/__tests__/permissionGetters.test.ts
+++ b/src/__tests__/permissionGetters.test.ts
@@ -26,7 +26,16 @@ type PermissionGetter = (options?: GetPermissionOptions) => Promise<'granted'>
 // suite drives every getter through the contract they all share — guard, `'granted'` short-circuit
 // and options forwarding — leaving the active trigger/acquire mechanics to `_acquirePermission` and
 // `_triggers` tests. The `passive` flag marks the three getters that intentionally never prompt.
-const getters: ReadonlyArray<{ label: string; getter: PermissionGetter; name: string; passive?: true }> = [
+// `descriptor` is the exact object the getter is expected to pass to `navigator.permissions.query()`;
+// it defaults to `{ name }` and is only spelled out for getters that add extra descriptor members
+// (e.g. `getPushPermission` must query with `userVisibleOnly: true`).
+const getters: ReadonlyArray<{
+	label: string
+	getter: PermissionGetter
+	name: string
+	passive?: true
+	descriptor?: PermissionDescriptor
+}> = [
 	{ label: 'getCameraPermission', getter: getCameraPermission, name: 'camera' },
 	{ label: 'getMicrophonePermission', getter: getMicrophonePermission, name: 'microphone' },
 	{ label: 'getGeolocationPermission', getter: getGeolocationPermission, name: 'geolocation' },
@@ -35,7 +44,13 @@ const getters: ReadonlyArray<{ label: string; getter: PermissionGetter; name: st
 	{ label: 'getPersistentStoragePermission', getter: getPersistentStoragePermission, name: 'persistent-storage' },
 	{ label: 'getScreenWakeLockPermission', getter: getScreenWakeLockPermission, name: 'screen-wake-lock' },
 	{ label: 'getStorageAccessPermission', getter: getStorageAccessPermission, name: 'storage-access' },
-	{ label: 'getPushPermission', getter: getPushPermission, name: 'push', passive: true },
+	{
+		label: 'getPushPermission',
+		getter: getPushPermission,
+		name: 'push',
+		passive: true,
+		descriptor: { name: 'push', userVisibleOnly: true } as PermissionDescriptor,
+	},
 	{ label: 'getClipboardReadPermission', getter: getClipboardReadPermission, name: 'clipboard-read', passive: true },
 	{
 		label: 'getClipboardWritePermission',
@@ -67,13 +82,26 @@ describe('dedicated permission getters', () => {
 
 		// On an already-`'granted'` state both kinds short-circuit to `'granted'` without ever firing
 		// a trigger, so this asserts the hardcoded name for all eleven without mocking native APIs.
-		it.each(getters)('$label queries "$name" and resolves with "granted"', async ({ getter, name }) => {
+		it.each(getters)('$label queries "$name" and resolves with "granted"', async ({ getter, name, descriptor }) => {
 			const status = new PermissionStatus() as unknown as MockPermissionStatus
 			status.state = 'granted'
 			mockPermissionsQuery.mockResolvedValueOnce(status)
 
 			await expect(getter()).resolves.toBe('granted')
-			expect(mockPermissionsQuery).toHaveBeenCalledWith({ name })
+			expect(mockPermissionsQuery).toHaveBeenCalledWith(descriptor ?? { name })
+		})
+
+		// End-to-end guard for the push bug (#167): `query({ name: 'push' })` throws a `TypeError` on
+		// browsers that can't query the name (Firefox/Safari) — the passive getter must surface a
+		// `NotSupportedError` `DOMException`, never the raw `TypeError`.
+		it('getPushPermission normalizes a query() TypeError to a NotSupportedError DOMException', async () => {
+			mockPermissionsQuery.mockImplementationOnce(() => {
+				throw new TypeError("'push' is not a valid enum value of type PermissionName")
+			})
+
+			const promise = getPushPermission()
+			await expect(promise).rejects.toBeInstanceOf(DOMException)
+			await expect(promise).rejects.toMatchObject({ name: 'NotSupportedError' })
 		})
 
 		describe('options forwarding', () => {

--- a/src/getPermission.ts
+++ b/src/getPermission.ts
@@ -5,6 +5,15 @@ export interface GetPermissionOptions {
 	timeout?: number
 }
 
+// The DOM `PermissionDescriptor` only declares `name`, but some permissions need extra members to be
+// queryable — notably `push`, which Chromium rejects unless `userVisibleOnly: true` is supplied
+// (silent push is not allowed). Widening the descriptor lets a dedicated getter pass those members
+// through, mirroring how the active primitive `acquirePermission` receives a permission-specific
+// `trigger`: the name-specific knowledge stays in the getter, the primitive stays generic.
+export interface PermissionQueryDescriptor extends PermissionDescriptor {
+	userVisibleOnly?: boolean
+}
+
 // `clipboard-read` / `clipboard-write` are valid at runtime but not (yet) in the DOM
 // `PermissionName` union — this narrow assertion satisfies the typed parameter from one place.
 export const asPermissionName = (name: string): PermissionName => name as PermissionName
@@ -17,14 +26,15 @@ export const asPermissionName = (name: string): PermissionName => name as Permis
  * Since nothing transitions `'prompt'` on its own, the wait must be bounded by `signal` and/or
  * `timeout`; with neither, it rejects immediately with `InvalidStateError` rather than hanging.
  *
- * @param permissionName    Name of the permission. @see https://w3c.github.io/permissions/#enumdef-permissionname
+ * @param permission         Permission name, or a full descriptor for permissions that need extra
+ *                           query members (e.g. `{ name: 'push', userVisibleOnly: true }`)
  * @param options.signal    Optional AbortSignal to cancel the pending wait
  * @param options.timeout   Optional timeout in milliseconds; rejects with a `TimeoutError`
  * @returns A promise resolved with `'granted'`
- * @throws {DOMException} `NotSupportedError`, `NotAllowedError` (denied), `InvalidStateError` or `TimeoutError`
+ * @throws {DOMException} `NotSupportedError` (API absent or name non-queryable), `NotAllowedError` (denied), `InvalidStateError` or `TimeoutError`
  */
 const getPermission = async (
-	permissionName: PermissionName,
+	permission: PermissionName | PermissionQueryDescriptor,
 	{ signal, timeout }: GetPermissionOptions = {}
 ): Promise<'granted'> => {
 	if (!navigator.permissions) {
@@ -33,7 +43,23 @@ const getPermission = async (
 
 	signal?.throwIfAborted()
 
-	const permissionStatus = await navigator.permissions.query({ name: permissionName })
+	const descriptor = typeof permission === 'string' ? { name: permission } : permission
+
+	let permissionStatus: PermissionStatus
+	try {
+		permissionStatus = await navigator.permissions.query(descriptor)
+	} catch (error) {
+		// A passive watcher has no native trigger to fall through to (unlike `acquirePermission` /
+		// `getUserMediaStream`, which retry via `getUserMedia` / `requestMIDIAccess`). When the browser
+		// can't query the name — a non-queryable descriptor (Firefox/Safari) or `push` rejected for
+		// lacking `userVisibleOnly` — it throws a `TypeError`. Normalize it to a `DOMException` so the
+		// library never leaks a raw `TypeError`, honoring the contract that every entry point throws a
+		// `DOMException`. Any other query error propagates unchanged.
+		if (error instanceof TypeError) {
+			throw new DOMException(`Permission "${descriptor.name}" cannot be queried`, 'NotSupportedError')
+		}
+		throw error
+	}
 
 	signal?.throwIfAborted()
 

--- a/src/getPermission.ts
+++ b/src/getPermission.ts
@@ -5,11 +5,6 @@ export interface GetPermissionOptions {
 	timeout?: number
 }
 
-// The DOM `PermissionDescriptor` only declares `name`, but some permissions need extra members to be
-// queryable — notably `push`, which Chromium rejects unless `userVisibleOnly: true` is supplied
-// (silent push is not allowed). Widening the descriptor lets a dedicated getter pass those members
-// through, mirroring how the active primitive `acquirePermission` receives a permission-specific
-// `trigger`: the name-specific knowledge stays in the getter, the primitive stays generic.
 export interface PermissionQueryDescriptor extends PermissionDescriptor {
 	userVisibleOnly?: boolean
 }
@@ -49,12 +44,6 @@ const getPermission = async (
 	try {
 		permissionStatus = await navigator.permissions.query(descriptor)
 	} catch (error) {
-		// A passive watcher has no native trigger to fall through to (unlike `acquirePermission` /
-		// `getUserMediaStream`, which retry via `getUserMedia` / `requestMIDIAccess`). When the browser
-		// can't query the name — a non-queryable descriptor (Firefox/Safari) or `push` rejected for
-		// lacking `userVisibleOnly` — it throws a `TypeError`. Normalize it to a `DOMException` so the
-		// library never leaks a raw `TypeError`, honoring the contract that every entry point throws a
-		// `DOMException`. Any other query error propagates unchanged.
 		if (error instanceof TypeError) {
 			throw new DOMException(`Permission "${descriptor.name}" cannot be queried`, 'NotSupportedError')
 		}

--- a/src/getPushPermission.ts
+++ b/src/getPushPermission.ts
@@ -5,7 +5,12 @@ import getPermission, { type GetPermissionOptions } from './getPermission'
  * {@link getPermission}: it never prompts, because `push` needs consumer infrastructure the library
  * can't synthesize (a service worker + VAPID key). Trigger via `pushManager.subscribe(...)` and
  * bound the `'prompt'` wait with `signal` and/or `timeout`.
+ *
+ * Queries `push` with `userVisibleOnly: true` because Chromium rejects the descriptor otherwise
+ * (silent push is not allowed). On browsers that can't query `push` at all (Firefox/Safari), the
+ * underlying `TypeError` is normalized to a `NotSupportedError` `DOMException` by {@link getPermission}.
  */
-const getPushPermission = (options?: GetPermissionOptions): Promise<'granted'> => getPermission('push', options)
+const getPushPermission = (options?: GetPermissionOptions): Promise<'granted'> =>
+	getPermission({ name: 'push', userVisibleOnly: true }, options)
 
 export default getPushPermission

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,6 @@ export { default as getPersistentStoragePermission } from './getPersistentStorag
 export { default as getPushPermission } from './getPushPermission'
 export { default as getScreenWakeLockPermission } from './getScreenWakeLockPermission'
 export { default as getStorageAccessPermission } from './getStorageAccessPermission'
-export type { GetPermissionOptions } from './getPermission'
+export type { GetPermissionOptions, PermissionQueryDescriptor } from './getPermission'
 export type { WatchPermissionOptions } from './watchPermission'
 export type { GetUserMediaStreamOptions } from './getUserMediaStream'


### PR DESCRIPTION
## Summary
`getPushPermission` could never resolve. It delegated to `getPermission('push', options)`, which called `navigator.permissions.query({ name: 'push' })` with **no** `userVisibleOnly` and **no** `try/catch`. Chromium rejects that descriptor (silent push is not allowed) and Firefox/Safari can't query the `push` name at all — so `query()` threw a raw `TypeError` that propagated unchanged, in violation of the library's contract that every entry point rejects with a `DOMException`.

This makes `getPushPermission` able to read the `push` state on Chromium and guarantees a `DOMException` everywhere else.

## Changes
- **`getPermission`**: widened its first argument to accept a full `PermissionQueryDescriptor` (`PermissionDescriptor` + optional `userVisibleOnly`) in addition to a bare `PermissionName` — backward compatible, a `string` still works. Push-specific knowledge stays in the dedicated getter, mirroring how the active primitive `acquirePermission` receives a permission-specific `trigger`.
- **`getPermission`**: wrapped `query()` so a non-queryable `TypeError` is normalized to a `NotSupportedError` `DOMException`. A passive watcher has no native trigger to fall through to (unlike `acquirePermission` / `getUserMediaStream`), so "name not queryable" is genuinely "not supported". Any other query error still propagates unchanged.
- **`getPushPermission`**: now delegates `getPermission({ name: 'push', userVisibleOnly: true }, options)`.
- **Tests**: added the passive `query()`-throws path (normalization to `NotSupportedError`), a non-`TypeError` propagation guard, full-descriptor forwarding, and an end-to-end `getPushPermission` normalization case. The parametrized getter suite now asserts the exact descriptor (`{ name: 'push', userVisibleOnly: true }`) for push.
- **README**: documented the new passive-getter normalization (vs. `checkPermission` still propagating the raw error) and push's `userVisibleOnly` query.

This also closes the test-coverage gap #168 (the suite never exercised a `query()` that throws on the passive path); the active-path fall-through it mentions is already covered by the existing `_acquirePermission` / `getUserMediaStream` tests.

## Test plan
- [ ] `yarn typecheck` passes
- [ ] `yarn test:ci` passes — 150 tests, 100% coverage maintained
- [ ] `yarn build` and demo build pass
- [ ] `yarn lint` + `yarn format:check` pass
- [ ] On Chromium, `getPushPermission()` resolves `'granted'` when push is granted (no longer rejects with a raw `TypeError`)
- [ ] On Firefox/Safari, `getPushPermission()` rejects with a `NotSupportedError` `DOMException`, not a raw `TypeError`

## Breaking changes
None. `getPushPermission`'s signature is unchanged; `getPermission` is only widened (a `PermissionName` string is still accepted). The observable behavior change is the intended fix: `getPushPermission` can now resolve on Chromium and always rejects with a `DOMException`.

Closes #167
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)