### PR TITLE
test: Cover query() promise rejection for the non-queryable TypeError path

### DIFF
--- a/src/__tests__/_acquirePermission.test.ts
+++ b/src/__tests__/_acquirePermission.test.ts
@@ -88,14 +88,14 @@ describe('acquirePermission', () => {
 		// the trigger still surfaces the real dialog instead of leaking the `TypeError`.
 		it.each([
 			{
-				mode: 'throws a TypeError synchronously',
+				mode: 'throws synchronously',
 				fail: () =>
 					mockPermissionsQuery.mockImplementationOnce(() => {
 						throw new TypeError("'camera' is not a valid enum value of type PermissionName")
 					}),
 			},
 			{
-				mode: 'rejects with a TypeError',
+				mode: 'rejects its promise',
 				fail: () =>
 					mockPermissionsQuery.mockRejectedValueOnce(
 						new TypeError("'camera' is not a valid enum value of type PermissionName")

--- a/src/__tests__/_acquirePermission.test.ts
+++ b/src/__tests__/_acquirePermission.test.ts
@@ -83,10 +83,9 @@ describe('acquirePermission', () => {
 			await expect(acquirePermission('camera', vi.fn())).rejects.toEqual(new Error('ERR'))
 		})
 
-		// `query()` fails for a permission name the browser won't query (Firefox/Safari:
+		// `query()` throws a `TypeError` for a permission name the browser won't query (Firefox/Safari:
 		// camera/microphone/midi) even though the trigger's native API works. Treat it as `'prompt'` so
-		// the trigger still surfaces the real dialog instead of leaking the `TypeError`. The browser
-		// surfaces this as a *rejected* promise, not a synchronous throw, so cover both shapes.
+		// the trigger still surfaces the real dialog instead of leaking the `TypeError`.
 		it.each([
 			{
 				mode: 'throws a TypeError synchronously',

--- a/src/__tests__/_acquirePermission.test.ts
+++ b/src/__tests__/_acquirePermission.test.ts
@@ -83,13 +83,27 @@ describe('acquirePermission', () => {
 			await expect(acquirePermission('camera', vi.fn())).rejects.toEqual(new Error('ERR'))
 		})
 
-		// `query()` throws a `TypeError` for a permission name the browser won't query (Firefox/Safari:
+		// `query()` fails for a permission name the browser won't query (Firefox/Safari:
 		// camera/microphone/midi) even though the trigger's native API works. Treat it as `'prompt'` so
-		// the trigger still surfaces the real dialog instead of leaking the `TypeError`.
-		it('treats a non-queryable name (query throws TypeError) as "prompt" and fires the trigger', async () => {
-			mockPermissionsQuery.mockImplementationOnce(() => {
-				throw new TypeError("'camera' is not a valid enum value of type PermissionName")
-			})
+		// the trigger still surfaces the real dialog instead of leaking the `TypeError`. The browser
+		// surfaces this as a *rejected* promise, not a synchronous throw, so cover both shapes.
+		it.each([
+			{
+				mode: 'throws a TypeError synchronously',
+				fail: () =>
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						throw new TypeError("'camera' is not a valid enum value of type PermissionName")
+					}),
+			},
+			{
+				mode: 'rejects with a TypeError',
+				fail: () =>
+					mockPermissionsQuery.mockRejectedValueOnce(
+						new TypeError("'camera' is not a valid enum value of type PermissionName")
+					),
+			},
+		])('treats a non-queryable name (query $mode) as "prompt" and fires the trigger', async ({ fail }) => {
+			fail()
 			const trigger = vi.fn().mockResolvedValueOnce(undefined)
 
 			await expect(acquirePermission('camera', trigger)).resolves.toBe('granted')

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -80,9 +80,6 @@ describe('getPermission', () => {
 			await expect(getPermission('microphone')).rejects.toEqual(new Error('ERR'))
 		})
 
-		// A browser that can't query a permission name surfaces the failure as a *rejected* promise, not
-		// a synchronous throw; cover both so the `await query()` + try/catch is proven against the shape
-		// the browser actually produces.
 		it.each([
 			{
 				mode: 'throws synchronously',

--- a/src/__tests__/getPermission.test.ts
+++ b/src/__tests__/getPermission.test.ts
@@ -80,10 +80,26 @@ describe('getPermission', () => {
 			await expect(getPermission('microphone')).rejects.toEqual(new Error('ERR'))
 		})
 
-		it('normalizes a TypeError from query() to a NotSupportedError DOMException', async () => {
-			mockPermissionsQuery.mockImplementationOnce(() => {
-				throw new TypeError("Failed to read the 'userVisibleOnly' property")
-			})
+		// A browser that can't query a permission name surfaces the failure as a *rejected* promise, not
+		// a synchronous throw; cover both so the `await query()` + try/catch is proven against the shape
+		// the browser actually produces.
+		it.each([
+			{
+				mode: 'throws synchronously',
+				fail: () =>
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						throw new TypeError("Failed to read the 'userVisibleOnly' property")
+					}),
+			},
+			{
+				mode: 'rejects its promise',
+				fail: () =>
+					mockPermissionsQuery.mockRejectedValueOnce(
+						new TypeError("Failed to read the 'userVisibleOnly' property")
+					),
+			},
+		])('normalizes a TypeError from query() ($mode) to a NotSupportedError DOMException', async ({ fail }) => {
+			fail()
 
 			const promise = getPermission('push')
 			await expect(promise).rejects.toBeInstanceOf(DOMException)

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -121,10 +121,9 @@ describe('getUserMediaStream', () => {
 			})
 
 			describe('permission name not queryable (Firefox/Safari)', () => {
-				// `query()` fails for a device the browser supports through `getUserMedia` but won't let you
-				// query (Firefox: camera/microphone). The call must fall through to the stream acquisition
-				// rather than leaking the `TypeError`. The browser surfaces this as a *rejected* promise,
-				// not a synchronous throw, so cover both shapes.
+				// `query()` throws a `TypeError` for a device the browser supports through `getUserMedia`
+				// but won't let you query (Firefox: camera/microphone). The call must fall through to the
+				// stream acquisition rather than leaking the `TypeError`.
 				it.each([
 					{
 						mode: 'throws a TypeError synchronously',

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -121,13 +121,27 @@ describe('getUserMediaStream', () => {
 			})
 
 			describe('permission name not queryable (Firefox/Safari)', () => {
-				// `query()` throws a `TypeError` for a device the browser supports through `getUserMedia`
-				// but won't let you query (Firefox: camera/microphone). The call must fall through to the
-				// stream acquisition rather than leaking the `TypeError`.
-				it('falls through to acquireMediaStream when query throws a TypeError', async () => {
-					mockPermissionsQuery.mockImplementationOnce(() => {
-						throw new TypeError("'camera' is not a valid enum value of type PermissionName")
-					})
+				// `query()` fails for a device the browser supports through `getUserMedia` but won't let you
+				// query (Firefox: camera/microphone). The call must fall through to the stream acquisition
+				// rather than leaking the `TypeError`. The browser surfaces this as a *rejected* promise,
+				// not a synchronous throw, so cover both shapes.
+				it.each([
+					{
+						mode: 'throws a TypeError synchronously',
+						fail: () =>
+							mockPermissionsQuery.mockImplementationOnce(() => {
+								throw new TypeError("'camera' is not a valid enum value of type PermissionName")
+							}),
+					},
+					{
+						mode: 'rejects with a TypeError',
+						fail: () =>
+							mockPermissionsQuery.mockRejectedValueOnce(
+								new TypeError("'camera' is not a valid enum value of type PermissionName")
+							),
+					},
+				])('falls through to acquireMediaStream when query $mode', async ({ fail }) => {
+					fail()
 					mockAcquireMediaStream.mockResolvedValueOnce(FAKE_STREAM)
 
 					await expect(getUserMediaStream('camera', { video: true })).resolves.toBe(FAKE_STREAM)

--- a/src/__tests__/getUserMediaStream.test.ts
+++ b/src/__tests__/getUserMediaStream.test.ts
@@ -126,14 +126,14 @@ describe('getUserMediaStream', () => {
 				// stream acquisition rather than leaking the `TypeError`.
 				it.each([
 					{
-						mode: 'throws a TypeError synchronously',
+						mode: 'throws synchronously',
 						fail: () =>
 							mockPermissionsQuery.mockImplementationOnce(() => {
 								throw new TypeError("'camera' is not a valid enum value of type PermissionName")
 							}),
 					},
 					{
-						mode: 'rejects with a TypeError',
+						mode: 'rejects its promise',
 						fail: () =>
 							mockPermissionsQuery.mockRejectedValueOnce(
 								new TypeError("'camera' is not a valid enum value of type PermissionName")

--- a/src/__tests__/permissionGetters.test.ts
+++ b/src/__tests__/permissionGetters.test.ts
@@ -88,15 +88,34 @@ describe('dedicated permission getters', () => {
 			expect(mockPermissionsQuery).toHaveBeenCalledWith(descriptor ?? { name })
 		})
 
-		it('getPushPermission normalizes a query() TypeError to a NotSupportedError DOMException', async () => {
-			mockPermissionsQuery.mockImplementationOnce(() => {
-				throw new TypeError("'push' is not a valid enum value of type PermissionName")
-			})
+		// Firefox/Safari can't query `push`; the failure reaches us as a *rejected* promise, not a
+		// synchronous throw. Cover both shapes so this regression (the bug behind #167) stays caught
+		// however the browser surfaces it.
+		it.each([
+			{
+				mode: 'throws synchronously',
+				fail: () =>
+					mockPermissionsQuery.mockImplementationOnce(() => {
+						throw new TypeError("'push' is not a valid enum value of type PermissionName")
+					}),
+			},
+			{
+				mode: 'rejects its promise',
+				fail: () =>
+					mockPermissionsQuery.mockRejectedValueOnce(
+						new TypeError("'push' is not a valid enum value of type PermissionName")
+					),
+			},
+		])(
+			'getPushPermission normalizes a query() TypeError ($mode) to a NotSupportedError DOMException',
+			async ({ fail }) => {
+				fail()
 
-			const promise = getPushPermission()
-			await expect(promise).rejects.toBeInstanceOf(DOMException)
-			await expect(promise).rejects.toMatchObject({ name: 'NotSupportedError' })
-		})
+				const promise = getPushPermission()
+				await expect(promise).rejects.toBeInstanceOf(DOMException)
+				await expect(promise).rejects.toMatchObject({ name: 'NotSupportedError' })
+			}
+		)
 
 		describe('options forwarding', () => {
 			// Parametrized over every getter: an already-aborted signal makes both `acquirePermission`

--- a/src/__tests__/permissionGetters.test.ts
+++ b/src/__tests__/permissionGetters.test.ts
@@ -88,9 +88,6 @@ describe('dedicated permission getters', () => {
 			expect(mockPermissionsQuery).toHaveBeenCalledWith(descriptor ?? { name })
 		})
 
-		// Firefox/Safari can't query `push`; the failure reaches us as a *rejected* promise, not a
-		// synchronous throw. Cover both shapes so this regression (the bug behind #167) stays caught
-		// however the browser surfaces it.
 		it.each([
 			{
 				mode: 'throws synchronously',


### PR DESCRIPTION
## Summary
`navigator.permissions.query()` surfaces a non-queryable permission name as a **rejected promise**, not a synchronous throw. Every existing `TypeError` test simulated a synchronous `throw`, so the `await query()` + `try/catch` was never proven against the shape the browser actually produces. This addresses #168's exact wording — *"No test makes `query()` reject with a `TypeError`."*

The two cases #168 originally requested were added by #169 (the fix for #167), but only as synchronous throws; this closes the remaining async-rejection gap.

## Changes
- Parametrize the four `query()`-throws tests over **both** failure modes via `it.each`, adding a `mockRejectedValueOnce(new TypeError(...))` variant alongside the existing synchronous throw:
  - `getPermission.test.ts` — passive normalization to a `NotSupportedError` `DOMException`
  - `permissionGetters.test.ts` — `getPushPermission` normalization (the #167 regression site)
  - `_acquirePermission.test.ts` — active fall-through that still fires the trigger
  - `getUserMediaStream.test.ts` — active fall-through that still delegates to `acquireMediaStream`
- Test-only change: no production code, public API, or documentation touched.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:ci` — 154 tests pass, coverage stays at 100% (statements/branches/functions/lines)
- [x] `yarn build`
- [x] `yarn lint`
- [x] `yarn format:check`

Closes #168