### PR TITLE
build(deps): Bump undici to patched 6.27.0 and 7.28.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,14 +4750,14 @@ uglify-js@^3.1.4:
   integrity "sha1-4suf4025y0z3410dJt/qKOCafQY= sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g=="
 
 undici@^6.23.0, undici@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.25.0.tgz#8c4efb8c998dc187fc1cfb5dde1ef19a211849fb"
-  integrity sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 undici@^7.0.0, undici@^7.25.0:
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
-  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Contexte

9 alertes de sécurité Dependabot ouvertes, **toutes pour `undici`** (2 high, 3 moderate, 4 low), dans `yarn.lock`.

`undici` est une dépendance **transitive de scope `development`** — via `semantic-release` (`@actions/core`, `node-gyp`) pour la ligne 6.x, et `jsdom` (tests) + `@semantic-release/github` pour la ligne 7.x. La lib publie uniquement `dist/` avec **0 dépendance runtime**, donc `undici` n'est **jamais livré** aux consommateurs : impact réel nul sur le paquet publié, mais les alertes polluent l'onglet Security.

## Changement

Les deux lignes verrouillées vulnérables sont re-résolues vers leurs versions patchées, **dans les plages `^` existantes** (aucun changement de `package.json`) :

- `undici 6.25.0 → 6.27.0`
- `undici 7.25.0 → 7.28.0`

Corrige notamment `GHSA-hm92-r4w5-c3mj` et `GHSA-vmh5-mc38-953g` (high), `GHSA-p88m-4jfj-68fv` / `GHSA-pr7r-676h-xcf6` (moderate), et les advisories low-severity Set-Cookie / keep-alive associées. Une fois mergé sur `main`, Dependabot re-scanne et ferme automatiquement les 9 alertes.

## Vérifications

- Diff minimal (6/6 lignes, uniquement `undici`) ; plus aucune version vulnérable dans `yarn.lock`.
- `yarn install --frozen-lockfile` cohérent.
- Hooks pre-commit (`typecheck` + `test:ci` — jsdom tourne avec undici 7.28.0 — + `lint`) OK.

## Note

Commit de type `build(deps)` volontaire : ce patch ne concerne pas le paquet publié, donc **pas de release no-op** déclenchée au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
